### PR TITLE
[HEL-4883] | Flutter Android Embedded View Purchases Fail

### DIFF
--- a/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
+++ b/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
@@ -535,7 +535,8 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
     // Create and set delegate.
     // When useDefaultDelegate is true, we still explicitly create a PlayStorePaywallDelegate
-    // so that its activityProvider can fall back to the Flutter plugin's activity reference.
+    // so that its activityProvider can use the Flutter plugin's activity reference as a
+    // secondary option when the SDK's tracker has no activity (e.g. embedded-view flows).
     if (!parsed.useDefaultDelegate) {
       Helium.config.heliumPaywallDelegate = CustomPaywallDelegate(parsed.delegateType, channel)
     } else {
@@ -543,8 +544,8 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         activityProvider = {
           IActivityProvider {
             // Prefer the SDK's own tracker (works for presentPaywall flows where a new
-            // Activity is launched), then fall back to the Flutter plugin's activity
-            // reference (needed for embedded-view flows).
+            // Activity is launched), then use the Flutter plugin's activity reference
+            // for embedded-view flows.
             Helium.activityTracker?.getCurrentActivity()
               ?: activity?.takeIf { !it.isFinishing }
           }

--- a/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
+++ b/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
@@ -42,6 +42,7 @@ import com.tryhelium.paywall.core.HeliumLightDarkMode
 import com.tryhelium.paywall.core.PaywallPresentationConfig
 import com.tryhelium.paywall.delegate.HeliumPaywallDelegate
 import com.tryhelium.paywall.delegate.PlayStorePaywallDelegate
+import com.tryhelium.paywall.core.IActivityProvider
 import com.tryhelium.paywall.core.logger.HeliumLogger
 import com.tryhelium.paywall.core.HeliumWrapperSdkConfig
 import com.android.billingclient.api.ProductDetails
@@ -532,9 +533,26 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       Helium.config.defaultLoadingBudgetInMs = loadingBudgetMs
     }
 
-    // Create and set delegate if needed
+    // Create and set delegate.
+    // When useDefaultDelegate is true, we still explicitly create a PlayStorePaywallDelegate
+    // so that its activityProvider can fall back to the Flutter plugin's activity reference.
     if (!parsed.useDefaultDelegate) {
       Helium.config.heliumPaywallDelegate = CustomPaywallDelegate(parsed.delegateType, channel)
+    } else {
+      Helium.config.heliumPaywallDelegate = PlayStorePaywallDelegate(
+        activityProvider = {
+          IActivityProvider {
+            // Prefer the SDK's own tracker (works for presentPaywall flows where a new
+            // Activity is launched), then fall back to the Flutter plugin's activity
+            // reference (needed for embedded-view flows).
+            Helium.activityTracker?.getCurrentActivity()
+              ?: activity?.takeIf { !it.isFinishing }
+          }
+        },
+        context = parsed.context,
+        consumableIds = parsed.consumableProductIds?.toSet(),
+        logger = Helium.config.logger
+      )
     }
 
     // Always write API endpoint (null clears a previous override)
@@ -568,7 +586,7 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       }
     }
     globalEventListener = listener
-    Helium.shared.addPaywallEventListener(listener)
+    Helium.shared.addHeliumEventListener(listener)
   }
 
   companion object {

--- a/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
+++ b/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
@@ -533,29 +533,6 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       Helium.config.defaultLoadingBudgetInMs = loadingBudgetMs
     }
 
-    // Create and set delegate.
-    // When useDefaultDelegate is true, we still explicitly create a PlayStorePaywallDelegate
-    // so that its activityProvider can use the Flutter plugin's activity reference as a
-    // secondary option when the SDK's tracker has no activity (e.g. embedded-view flows).
-    if (!parsed.useDefaultDelegate) {
-      Helium.config.heliumPaywallDelegate = CustomPaywallDelegate(parsed.delegateType, channel)
-    } else {
-      Helium.config.heliumPaywallDelegate = PlayStorePaywallDelegate(
-        activityProvider = {
-          IActivityProvider {
-            // Prefer the SDK's own tracker (works for presentPaywall flows where a new
-            // Activity is launched), then use the Flutter plugin's activity reference
-            // for embedded-view flows.
-            Helium.activityTracker?.getCurrentActivity()
-              ?: activity?.takeIf { !it.isFinishing }
-          }
-        },
-        context = parsed.context,
-        consumableIds = parsed.consumableProductIds?.toSet(),
-        logger = Helium.config.logger
-      )
-    }
-
     // Always write API endpoint (null clears a previous override)
     Helium.config.customApiEndpoint = parsed.customApiEndpoint
 
@@ -572,6 +549,30 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
     // Set up bridging logger to forward native SDK logs to Flutter
     Helium.config.logger = BridgingLogger(channel)
+
+    // Create and set delegate.
+    // When useDefaultDelegate is true, we still explicitly create a PlayStorePaywallDelegate
+    // so that its activityProvider can use the Flutter plugin's activity reference
+    // (needed for embedded-view flows where the SDK's ActivityLifecycleTracker may not
+    // have the current activity).
+    if (!parsed.useDefaultDelegate) {
+      Helium.config.heliumPaywallDelegate = CustomPaywallDelegate(parsed.delegateType, channel)
+    } else {
+      Helium.config.heliumPaywallDelegate = PlayStorePaywallDelegate(
+        activityProvider = {
+          IActivityProvider {
+            // Prefer the Flutter plugin's activity reference (needed for embedded-view
+            // flows), then check the SDK's tracker (picks up new Activities launched by
+            // presentPaywall).
+            activity?.takeIf { !it.isFinishing }
+              ?: Helium.activityTracker?.getCurrentActivity()
+          }
+        },
+        context = parsed.context,
+        consumableIds = Helium.config.consumableIds,
+        logger = Helium.config.logger
+      )
+    }
   }
 
   private fun setupGlobalEventListener() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Android paywall delegate wiring and activity resolution, which can affect purchase/presentation flows in embedded views. Event listener registration is also swapped to a different API, potentially altering event delivery behavior.
> 
> **Overview**
> Fixes Android embedded-view paywall/purchase flows by always configuring a `Helium.config.heliumPaywallDelegate`: when `useDefaultDelegate` is true, it now explicitly instantiates `PlayStorePaywallDelegate` with an `activityProvider` that prefers the plugin’s current `activity` and falls back to `Helium.activityTracker`.
> 
> Updates global event forwarding to Flutter by registering via `Helium.shared.addHeliumEventListener(...)` (instead of `addPaywallEventListener`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85ef3306884906d9b4093b2d4cc6aa73570676b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Improved Android paywall handling: more reliable activity tracking and a clearer fallback path for paywall behavior, resulting in smoother purchase/paywall interactions.
  * Switched Android event registration to a broader event listener for more consistent and comprehensive event delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->