### PR TITLE
HEL-5226 add paddle purchase sync support to RevenueCat handler

### DIFF
--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -701,6 +701,7 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
           triggerName: triggerName,
           paywallName: paywallName,
           isSecondTry: isSecondTry,
+          paymentProcessor: event.paymentProcessor,
         ));
         break;
       case 'paywallOpenFailed':

--- a/packages/helium_flutter/lib/types/helium_types.dart
+++ b/packages/helium_flutter/lib/types/helium_types.dart
@@ -14,6 +14,21 @@ enum HeliumWebCheckoutProcessor {
   stripe,
 }
 
+/// Identifies which payment processor completed a purchase.
+enum HeliumPaymentProcessor {
+  appStore,
+  stripe,
+  paddle;
+
+  static HeliumPaymentProcessor? fromValue(String? value) {
+    if (value == null) return null;
+    for (final p in HeliumPaymentProcessor.values) {
+      if (p.name == value) return p;
+    }
+    return null;
+  }
+}
+
 class PaywallInfo {
   final String paywallTemplateName;
   final bool shouldShow;
@@ -127,12 +142,14 @@ class PurchaseSucceededEvent {
   final String triggerName;
   final String paywallName;
   final bool isSecondTry;
+  final HeliumPaymentProcessor? paymentProcessor;
 
   PurchaseSucceededEvent({
     required this.productId,
     required this.triggerName,
     required this.paywallName,
     required this.isSecondTry,
+    this.paymentProcessor,
   });
 }
 
@@ -227,6 +244,8 @@ class HeliumPaywallEvent {
   int? get fontsDownloadTimeTakenMS => _data['fontsDownloadTimeTakenMS'];
   int? get bundleDownloadTimeMS => _data['bundleDownloadTimeMS'];
   String? get canonicalJoinTransactionId => _data['canonicalJoinTransactionId'];
+  HeliumPaymentProcessor? get paymentProcessor =>
+      HeliumPaymentProcessor.fromValue(_data['paymentProcessor'] as String?);
   bool? get dismissAll => _data['dismissAll'];
   bool? get isSecondTry => _data['isSecondTry'];
   String? get error => _data['error'];

--- a/packages/helium_flutter/lib/types/helium_types.dart
+++ b/packages/helium_flutter/lib/types/helium_types.dart
@@ -230,38 +230,45 @@ class HeliumPaywallEvent {
     return null;
   }
 
+  /// Returns `_data[key]` if it is of type [T], otherwise `null`. Guards
+  /// against native sending an unexpected value type for a given key.
+  T? _get<T>(String key) {
+    final v = _data[key];
+    return v is T ? v : null;
+  }
+
   // Type-safe getters
   Map<String, dynamic> get rawData => _data;
-  String get type => _data['type'] ?? '';
-  String? get triggerName => _data['triggerName'];
-  String? get paywallName => _data['paywallName'];
-  String? get productId => _data['productId'];
-  String? get buttonName => _data['buttonName'];
-  String? get configId => _data['configId'];
-  String? get impressionId => _data['impressionId'];
-  int? get responseTimeMs => _data['responseTimeMs'];
-  int? get configDownloadTimeMs => _data['configDownloadTimeMs'];
-  int? get fontsDownloadTimeTakenMS => _data['fontsDownloadTimeTakenMS'];
-  int? get bundleDownloadTimeMS => _data['bundleDownloadTimeMS'];
-  String? get canonicalJoinTransactionId => _data['canonicalJoinTransactionId'];
+  String get type => _get<String>('type') ?? '';
+  String? get triggerName => _get<String>('triggerName');
+  String? get paywallName => _get<String>('paywallName');
+  String? get productId => _get<String>('productId');
+  String? get buttonName => _get<String>('buttonName');
+  String? get configId => _get<String>('configId');
+  String? get impressionId => _get<String>('impressionId');
+  int? get responseTimeMs => _get<int>('responseTimeMs');
+  int? get configDownloadTimeMs => _get<int>('configDownloadTimeMs');
+  int? get fontsDownloadTimeTakenMS => _get<int>('fontsDownloadTimeTakenMS');
+  int? get bundleDownloadTimeMS => _get<int>('bundleDownloadTimeMS');
+  String? get canonicalJoinTransactionId => _get<String>('canonicalJoinTransactionId');
   HeliumPaymentProcessor? get paymentProcessor =>
-      HeliumPaymentProcessor.fromValue(_data['paymentProcessor'] as String?);
-  bool? get dismissAll => _data['dismissAll'];
-  bool? get isSecondTry => _data['isSecondTry'];
-  String? get error => _data['error'];
-  String? get paywallUnavailableReason => _data['paywallUnavailableReason'];
-  String? get customPaywallActionName => _data['actionName'];
+      HeliumPaymentProcessor.fromValue(_get<String>('paymentProcessor'));
+  bool? get dismissAll => _get<bool>('dismissAll');
+  bool? get isSecondTry => _get<bool>('isSecondTry');
+  String? get error => _get<String>('error');
+  String? get paywallUnavailableReason => _get<String>('paywallUnavailableReason');
+  String? get customPaywallActionName => _get<String>('actionName');
   Map<String, dynamic>? get customPaywallActionParams => getSafeData(_data['params']);
   /// Unix timestamp in seconds
-  int? get timestamp => _data['timestamp'];
+  int? get timestamp => _get<int>('timestamp');
 
   // Deprecated getters for backwards compatibility
   /// @deprecated Use `paywallName` instead.
-  String? get paywallTemplateName => _data['paywallTemplateName'];
+  String? get paywallTemplateName => _get<String>('paywallTemplateName');
   /// @deprecated Use `productId` instead.
-  String? get productKey => _data['productKey'];
+  String? get productKey => _get<String>('productKey');
   /// @deprecated Use `buttonName` instead.
-  String? get ctaName => _data['ctaName'];
+  String? get ctaName => _get<String>('ctaName');
   /// @deprecated Use `error` instead.
-  String? get errorDescription => _data['errorDescription'];
+  String? get errorDescription => _get<String>('errorDescription');
 }

--- a/packages/helium_revenuecat/lib/src/revenue_cat_purchase_delegate.dart
+++ b/packages/helium_revenuecat/lib/src/revenue_cat_purchase_delegate.dart
@@ -16,15 +16,19 @@ class RevenueCatPurchaseDelegate extends HeliumPurchaseDelegate
   String get delegateType => 'h_revenuecat';
 
   final bool _stripePurchaseSyncDisabled;
-  bool _isSyncingStripePurchase = false;
+  final bool _paddlePurchaseSyncDisabled;
+  bool _isSyncingThirdPartyPayment = false;
 
   /// Creates a new [RevenueCatPurchaseDelegate].
   ///
-  /// Set [disableStripePurchaseSync] to `true` to disable automatic RevenueCat
-  /// entitlement syncing after Stripe purchases.
+  /// Set [disableStripePurchaseSync] or [disablePaddlePurchaseSync] to `true`
+  /// to disable automatic RevenueCat customer info refresh after a purchase
+  /// completed by that processor.
   RevenueCatPurchaseDelegate({
     bool disableStripePurchaseSync = false,
-  }) : _stripePurchaseSyncDisabled = disableStripePurchaseSync {
+    bool disablePaddlePurchaseSync = false,
+  })  : _stripePurchaseSyncDisabled = disableStripePurchaseSync,
+        _paddlePurchaseSyncDisabled = disablePaddlePurchaseSync {
     _syncAppUserId();
   }
 
@@ -228,38 +232,36 @@ class RevenueCatPurchaseDelegate extends HeliumPurchaseDelegate
   }
 
   // ---------------------------------------------------------------------------
-  // Stripe Auto-Syncing
+  // Third-Party Payment Sync
   // ---------------------------------------------------------------------------
 
   @override
   void onPaywallEvent(HeliumPaywallEvent event) {
-    if (!_stripePurchaseSyncDisabled &&
-        event.type == 'purchaseSucceeded' &&
-        _isStripePurchase(event)) {
-      _syncRevenueCatAfterStripePurchase();
+    if (event.type != 'purchaseSucceeded') return;
+    if (!_shouldSyncAfterThirdPartyPayment(event.paymentProcessor)) return;
+    _syncRevenueCatAfterThirdPartyPayment();
+  }
+
+  bool _shouldSyncAfterThirdPartyPayment(HeliumPaymentProcessor? processor) {
+    switch (processor) {
+      case HeliumPaymentProcessor.stripe:
+        return !_stripePurchaseSyncDisabled;
+      case HeliumPaymentProcessor.paddle:
+        return !_paddlePurchaseSyncDisabled;
+      case HeliumPaymentProcessor.appStore:
+      case null:
+        return false;
     }
   }
 
-  bool _isStripePurchase(HeliumPaywallEvent event) {
-    final txId = event.canonicalJoinTransactionId;
-    if (txId != null && txId.startsWith('si_')) {
-      return true;
-    }
-    final pid = event.productId;
-    if (pid != null && RegExp(r'^prod_\w+:price_\w+$').hasMatch(pid)) {
-      return true;
-    }
-    return false;
-  }
-
-  /// After a Stripe purchase completes, the RevenueCat SDK on-device has no way
-  /// to know that a new entitlement exists until its backend processes the Stripe
-  /// webhook. This method polls RevenueCat with progressive back-off to force a
-  /// customer info refresh, stopping early if the update listener fires
-  /// (~50s max).
-  Future<void> _syncRevenueCatAfterStripePurchase() async {
-    if (_isSyncingStripePurchase) return;
-    _isSyncingStripePurchase = true;
+  /// After a third-party payment (Stripe or Paddle) completes, the RevenueCat
+  /// SDK on-device has no way to know that a new entitlement exists until its
+  /// backend processes the provider webhook. This method polls RevenueCat with
+  /// progressive back-off to force a customer info refresh, stopping early if
+  /// the update listener fires (~50s max).
+  Future<void> _syncRevenueCatAfterThirdPartyPayment() async {
+    if (_isSyncingThirdPartyPayment) return;
+    _isSyncingThirdPartyPayment = true;
 
     try {
       bool synced = false;
@@ -297,9 +299,9 @@ class RevenueCatPurchaseDelegate extends HeliumPurchaseDelegate
         Purchases.removeCustomerInfoUpdateListener(listener);
       }
     } catch (e) {
-      log('[Helium] Error syncing RevenueCat after Stripe purchase: $e');
+      log('[Helium] Error syncing RevenueCat after third-party payment: $e');
     } finally {
-      _isSyncingStripePurchase = false;
+      _isSyncingThirdPartyPayment = false;
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches purchase-success event payloads and the RevenueCat post-purchase sync trigger logic, which could affect entitlement refresh timing/behavior for paid users. Scope is limited to event typing and a generalized sync path, with no direct payment processing changes.
> 
> **Overview**
> Adds a new `HeliumPaymentProcessor` enum and threads `paymentProcessor` through `HeliumPaywallEvent` and `PurchaseSucceededEvent`, including safer typed accessors to tolerate unexpected native event value types.
> 
> Generalizes RevenueCat’s post-purchase refresh logic from Stripe-only to *third-party payments* (Stripe/Paddle), adding per-processor disable flags and updating the sync trigger to use the new `paymentProcessor` field rather than heuristics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 946328ed88daa3cf7feb7221ff047cee4ef2c712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Purchase success events now include payment processor details, allowing identification of which processor (App Store, Stripe, or Paddle) completed each transaction

* **Improvements**
  * Third-party payment synchronization has been generalized to support multiple payment processors with enhanced refresh logic and better event handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->