### PR TITLE
Update Helium Android dependency to 4.4.1

### DIFF
--- a/packages/helium_flutter/CHANGELOG.md
+++ b/packages/helium_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.2
+- Updated Helium Android dependency to 4.4.1
+
 ## 3.3.1
 - Updated helium-swift dependency to 4.4.1
 

--- a/packages/helium_flutter/android/build.gradle
+++ b/packages/helium_flutter/android/build.gradle
@@ -48,7 +48,7 @@ android {
     }
 
     dependencies {
-        implementation("com.tryhelium.paywall:core:4.4.0")
+        implementation("com.tryhelium.paywall:core:4.4.1")
         implementation("com.google.code.gson:gson:2.10.1")
         implementation("com.android.billingclient:billing:8.0.0")
         testImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/packages/helium_flutter/lib/core/const/contants.dart
+++ b/packages/helium_flutter/lib/core/const/contants.dart
@@ -1,5 +1,5 @@
 // SDK version - keep in sync with pubspec.yaml
-const String heliumFlutterSdkVersion = '3.3.1';
+const String heliumFlutterSdkVersion = '3.3.2';
 
 //Native view type
 const String upsellViewForTrigger = 'upsellViewForTrigger';

--- a/packages/helium_flutter/pubspec.yaml
+++ b/packages/helium_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: helium_flutter
 description: "Flutter Paywall SDK for Helium. Remotely build and auto-optimize paywalls (tryhelium.com)"
 
 # Remember to update CHANGELOG.md when releasing a new version!!! (see CONTRIBUTING.md)
-version: 3.3.1
+version: 3.3.2
 
 homepage: https://tryhelium.com
 license: MIT

--- a/packages/helium_revenuecat/CHANGELOG.md
+++ b/packages/helium_revenuecat/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.2
+- Updated Helium Android dependency to 4.4.1
+
 ## 3.3.1
 - Updated helium-swift dependency to 4.4.1
 

--- a/packages/helium_revenuecat/pubspec.yaml
+++ b/packages/helium_revenuecat/pubspec.yaml
@@ -1,6 +1,6 @@
 name: helium_revenuecat
 description: "Helium RevenueCat SDK. Remotely build and auto-optimize paywalls (tryhelium.com)"
-version: 3.3.1
+version: 3.3.2
 homepage: https://tryhelium.com
 
 environment:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Primarily a dependency/version bump, but it updates the Android paywall core library which can change purchase/paywall behavior at runtime.
> 
> **Overview**
> Updates the Android Helium core dependency from `4.4.0` to `4.4.1` in the `helium_flutter` plugin.
> 
> Releases this change as version `3.3.2` by bumping package versions (`pubspec.yaml`), syncing the in-code SDK version constant, and adding matching changelog entries for both `helium_flutter` and `helium_revenuecat`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37bc80025f2f0c82e478c9965ea6fe088da1a409. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 3.3.2 for both Helium Flutter and Helium RevenueCat packages.
  * Updated Android-side Helium dependency to version 4.4.1.
  * Updated package manifests and version constants to reflect the new release version.
  * Updated changelog entries documenting the dependency update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->