### PR TITLE
[HEL-5291] | Custom Paywall traits on embedded paywall

### DIFF
--- a/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumNativeView.kt
+++ b/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumNativeView.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import io.flutter.plugin.platform.PlatformView
 import com.tryhelium.paywall.core.Helium
+import com.tryhelium.paywall.core.HeliumUserTraits
 import com.tryhelium.paywall.core.event.HeliumEventDictionaryMapper
 import com.tryhelium.paywall.core.event.PaywallEventHandlers
 import com.tryhelium.paywall.ui.HeliumPaywallView
@@ -25,7 +26,10 @@ class HeliumNativeView(
 
     init {
         val trigger = creationParams?.get("trigger") as? String ?: ""
-        view = upsellViewForTrigger(context, trigger)
+        @Suppress("UNCHECKED_CAST")
+        val customPaywallTraitsMap = creationParams?.get("customPaywallTraits") as? Map<String, Any>
+        val customPaywallTraits = convertToHeliumUserTraits(customPaywallTraitsMap)
+        view = upsellViewForTrigger(context, trigger, customPaywallTraits)
     }
 
     override fun getView(): View {
@@ -36,7 +40,11 @@ class HeliumNativeView(
         view.setViewTreeLifecycleOwner(null)
     }
 
-    private fun upsellViewForTrigger(context: Context, trigger: String): View {
+    private fun upsellViewForTrigger(
+        context: Context,
+        trigger: String,
+        customPaywallTraits: HeliumUserTraits?,
+    ): View {
         val eventListener = PaywallEventHandlers(onAnyEvent = { event ->
             val eventData = HeliumEventDictionaryMapper.toDictionary(event)
             Handler(Looper.getMainLooper()).post {
@@ -47,7 +55,7 @@ class HeliumNativeView(
                 }
             }
         })
-        
+
         return try {
             val paywallView = HeliumPaywallView(context = context)
             paywallView.layoutParams = android.view.ViewGroup.LayoutParams(
@@ -68,9 +76,13 @@ class HeliumNativeView(
                     // Remove listener so loadPaywall is only called once
                     v.removeOnAttachStateChangeListener(this)
                     try {
-                        paywallView.loadPaywall(trigger = trigger, navigationDispatcher = { command ->
-                            // Do nothing. Callers need to listen to the paywall events
-                        })
+                        paywallView.loadPaywall(
+                            trigger = trigger,
+                            navigationDispatcher = { command ->
+                                // Do nothing. Callers need to listen to the paywall events
+                            },
+                            customPaywallTraits = customPaywallTraits,
+                        )
                     } catch (e: Exception) {
                         Log.e("HeliumNativeView", "Failed to load paywall for trigger '$trigger'", e)
                     }

--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -829,10 +829,12 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
   Widget getUpsellWidget({
     required String trigger,
     PaywallEventHandlers? eventHandlers,
+    Map<String, dynamic>? customPaywallTraits,
   }) {
     _currentEventHandlers = eventHandlers;
     return UpsellWrapperWidget(
       trigger: trigger,
+      customPaywallTraits: _convertBooleansToMarkers(customPaywallTraits),
       fallbackPaywallWidget:
           _fallbackPaywallWidget ?? Text("No fallback view provided"),
       availabilityChecker: () => canPresentUpsell(trigger),
@@ -899,6 +901,7 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
 /// nearly synchronous.
 class UpsellWrapperWidget extends StatefulWidget {
   final String trigger;
+  final Map<String, dynamic>? customPaywallTraits;
   final Widget fallbackPaywallWidget;
   final Future<CanPresentUpsellResult?> Function() availabilityChecker;
   final void Function(String? paywallUnavailableReason)? onFallbackOpened;
@@ -909,6 +912,7 @@ class UpsellWrapperWidget extends StatefulWidget {
     required this.trigger,
     required this.fallbackPaywallWidget,
     required this.availabilityChecker,
+    this.customPaywallTraits,
     this.onFallbackOpened,
     this.onFallbackClosed,
   });
@@ -951,7 +955,10 @@ class _UpsellWrapperWidgetState extends State<UpsellWrapperWidget> {
           return const SizedBox.shrink();
         }
         if (snapshot.data?.canShow == true) {
-          return UpsellViewForTrigger(trigger: widget.trigger);
+          return UpsellViewForTrigger(
+            trigger: widget.trigger,
+            customPaywallTraits: widget.customPaywallTraits,
+          );
         } else {
           _onShowFallback(snapshot.data?.paywallUnavailableReason);
           return widget.fallbackPaywallWidget;
@@ -963,24 +970,38 @@ class _UpsellWrapperWidgetState extends State<UpsellWrapperWidget> {
 
 ///This widget used to present view based on [trigger]
 class UpsellViewForTrigger extends StatelessWidget {
-  const UpsellViewForTrigger({super.key, required this.trigger});
+  const UpsellViewForTrigger({
+    super.key,
+    required this.trigger,
+    this.customPaywallTraits,
+  });
   final String viewType = upsellViewForTrigger;
   final String trigger;
 
+  /// Optional custom paywall traits forwarded to the native paywall on load.
+  /// Booleans should already be marker-encoded via `_convertBooleansToMarkers`
+  /// before being supplied here so they survive the platform channel codec.
+  final Map<String, dynamic>? customPaywallTraits;
+
   @override
   Widget build(BuildContext context) {
+    final creationParams = <String, dynamic>{
+      'trigger': trigger,
+      if (customPaywallTraits != null)
+        'customPaywallTraits': customPaywallTraits,
+    };
     if (Platform.isAndroid) {
       return AndroidView(
         viewType: viewType,
         layoutDirection: TextDirection.ltr,
-        creationParams: {'trigger': trigger},
+        creationParams: creationParams,
         creationParamsCodec: const StandardMessageCodec(),
       );
     } else if (Platform.isIOS) {
       return UiKitView(
         viewType: viewType,
         layoutDirection: TextDirection.ltr,
-        creationParams: {'trigger': trigger},
+        creationParams: creationParams,
         creationParamsCodec: const StandardMessageCodec(),
       );
     } else {

--- a/packages/helium_flutter/lib/core/helium_flutter_platform.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_platform.dart
@@ -98,6 +98,7 @@ abstract class HeliumFlutterPlatform extends PlatformInterface {
   Widget getUpsellWidget({
     required String trigger,
     PaywallEventHandlers? eventHandlers,
+    Map<String, dynamic>? customPaywallTraits,
   });
 
   Future<bool> hasAnyActiveSubscription();

--- a/packages/helium_flutter/lib/helium_flutter.dart
+++ b/packages/helium_flutter/lib/helium_flutter.dart
@@ -137,12 +137,25 @@ class HeliumFlutter {
   Future<bool> handleDeepLink(String uri) =>
       HeliumFlutterPlatform.instance.handleDeepLink(uri);
 
+  /// Returns an embedded paywall widget for [trigger].
+  ///
+  /// [customPaywallTraits] are forwarded to the native paywall when it is
+  /// loaded. They are read once at platform-view creation time, so changing
+  /// the map on a later rebuild will not reload the paywall — recreate the
+  /// widget (e.g. via a different `key`) if you need fresh traits.
+  ///
+  /// Currently wired up on Android only; iOS ignores [customPaywallTraits]
+  /// for the embedded paywall path until the iOS SDK adds support.
   Widget getUpsellWidget({
     required String trigger,
     PaywallEventHandlers? eventHandlers,
+    Map<String, dynamic>? customPaywallTraits,
   }) =>
-      HeliumFlutterPlatform.instance
-          .getUpsellWidget(trigger: trigger, eventHandlers: eventHandlers);
+      HeliumFlutterPlatform.instance.getUpsellWidget(
+        trigger: trigger,
+        eventHandlers: eventHandlers,
+        customPaywallTraits: customPaywallTraits,
+      );
 
   /// Checks if the user has any active subscription (including non-renewable)
   Future<bool> hasAnyActiveSubscription() =>

--- a/packages/helium_flutter/test/helium_flutter_test.dart
+++ b/packages/helium_flutter/test/helium_flutter_test.dart
@@ -111,6 +111,7 @@ class MockHeliumFlutterPlatform
   Widget getUpsellWidget({
     required String trigger,
     PaywallEventHandlers? eventHandlers,
+    Map<String, dynamic>? customPaywallTraits,
   }) {
     return Text("upsell widget");
   }

--- a/packages/helium_stripe/test/helium_stripe_test.dart
+++ b/packages/helium_stripe/test/helium_stripe_test.dart
@@ -112,6 +112,7 @@ class MockHeliumFlutterPlatform
   Widget getUpsellWidget({
     required String trigger,
     PaywallEventHandlers? eventHandlers,
+    Map<String, dynamic>? customPaywallTraits,
   }) =>
       const Text('upsell widget');
   @override


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the embedded paywall (platform view) creation parameters and Android `loadPaywall` invocation to pass through user-provided trait data, which could affect paywall rendering/targeting and introduces new platform-bridge type conversion paths.
> 
> **Overview**
> Adds optional `customPaywallTraits` support to the embedded upsell widget API (`getUpsellWidget`) and forwards these traits through the Flutter platform-view `creationParams`.
> 
> On Android, `HeliumNativeView` now reads `customPaywallTraits`, converts marker-encoded values into `HeliumUserTraits`, and passes them into `HeliumPaywallView.loadPaywall(...)`. Public docs and test mocks are updated to include the new optional parameter, with iOS explicitly noted as currently ignoring it for embedded paywalls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c4d34b4a05eb9ac84b3ecfd278c6c645acb6cdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom paywall traits in the upsell widget API. The `getUpsellWidget` method now accepts an optional `customPaywallTraits` parameter, enabling greater flexibility in customizing paywall behavior and appearance.

* **Tests**
  * Updated test suite to reflect new API signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->