### PR TITLE
[HEL-4907] | Flutter SDK log levels

### DIFF
--- a/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/BridgingLogger.kt
+++ b/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/BridgingLogger.kt
@@ -24,23 +24,33 @@ class BridgingLogger(private val channel: MethodChannel) : HeliumLogger {
     private val mainHandler = Handler(Looper.getMainLooper())
 
     override fun e(message: String) {
-        sendLogEvent(level = 1, message = message)
+        if (logLevel.rawValue >= HeliumLogLevel.ERROR.rawValue) {
+            sendLogEvent(level = 1, message = message)
+        }
     }
 
     override fun w(message: String) {
-        sendLogEvent(level = 2, message = message)
+        if (logLevel.rawValue >= HeliumLogLevel.WARN.rawValue) {
+            sendLogEvent(level = 2, message = message)
+        }
     }
 
     override fun i(message: String) {
-        sendLogEvent(level = 3, message = message)
+        if (logLevel.rawValue >= HeliumLogLevel.INFO.rawValue) {
+            sendLogEvent(level = 3, message = message)
+        }
     }
 
     override fun d(message: String) {
-        sendLogEvent(level = 4, message = message)
+        if (logLevel.rawValue >= HeliumLogLevel.DEBUG.rawValue) {
+            sendLogEvent(level = 4, message = message)
+        }
     }
 
     override fun v(message: String) {
-        sendLogEvent(level = 5, message = message)
+        if (logLevel.rawValue >= HeliumLogLevel.VERBOSE.rawValue) {
+            sendLogEvent(level = 5, message = message)
+        }
     }
 
     private fun sendLogEvent(level: Int, message: String) {

--- a/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
+++ b/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
@@ -440,7 +440,7 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       "setLogLevel" -> {
         val rawValue = (call.arguments as? Number)?.toInt()
         val level = rawValue?.let { value ->
-          HeliumLogLevel.values().firstOrNull { it.rawValue == value }
+          HeliumLogLevel.entries.firstOrNull { it.rawValue == value }
         }
         if (level == null) {
           result.error("BAD_ARGS", "Invalid log level", null)

--- a/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
+++ b/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
@@ -41,6 +41,7 @@ import com.tryhelium.paywall.core.PaywallPresentationConfig
 import com.tryhelium.paywall.delegate.HeliumPaywallDelegate
 import com.tryhelium.paywall.delegate.PlayStorePaywallDelegate
 import com.tryhelium.paywall.core.IActivityProvider
+import com.tryhelium.paywall.core.logger.HeliumLogLevel
 import com.tryhelium.paywall.core.logger.HeliumLogger
 import com.tryhelium.paywall.core.HeliumWrapperSdkConfig
 import com.android.billingclient.api.ProductDetails
@@ -436,6 +437,18 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         // Web Checkout entitlements / redirects are not yet supported on Android.
         result.success(false)
       }
+      "setLogLevel" -> {
+        val rawValue = (call.arguments as? Number)?.toInt()
+        val level = rawValue?.let { value ->
+          HeliumLogLevel.values().firstOrNull { it.rawValue == value }
+        }
+        if (level == null) {
+          result.error("BAD_ARGS", "Invalid log level", null)
+        } else {
+          Helium.config.logLevel = level
+          result.success(null)
+        }
+      }
       else -> {
         result.notImplemented()
       }
@@ -565,8 +578,14 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     // Always write consumable product IDs (empty set clears previous values)
     Helium.config.consumableIds = parsed.consumableProductIds?.toSet() ?: emptySet()
 
-    // Set up bridging logger to forward native SDK logs to Flutter
-    Helium.config.logger = BridgingLogger(channel)
+    // Set up bridging logger to forward native SDK logs to Flutter.
+    // Carry over the currently effective log level so a pre-init setLogLevel
+    // call (or any prior override) survives the logger swap. The native
+    // initialize() will still apply the debug-build default afterwards if the
+    // host app never set a level explicitly.
+    val bridgingLogger = BridgingLogger(channel)
+    bridgingLogger.logLevel = Helium.config.logLevel
+    Helium.config.logger = bridgingLogger
 
     // Create and set delegate.
     // When useDefaultDelegate is true, we still explicitly create a PlayStorePaywallDelegate

--- a/packages/helium_flutter/ios/helium_flutter/Sources/helium_flutter/HeliumFlutterPlugin.swift
+++ b/packages/helium_flutter/ios/helium_flutter/Sources/helium_flutter/HeliumFlutterPlugin.swift
@@ -270,6 +270,14 @@ public class HeliumFlutterPlugin: NSObject, FlutterPlugin {
         case "resetPaddleEntitlements":
             Helium.shared.resetPaddleEntitlements()
             result(nil)
+        case "setLogLevel":
+            guard let rawValue = call.arguments as? Int,
+                  let level = HeliumLogLevel(rawValue: rawValue) else {
+                result(FlutterError(code: "BAD_ARGS", message: "Invalid log level", details: nil))
+                return
+            }
+            Helium.config.logLevel = level
+            result(nil)
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/packages/helium_flutter/lib/core/const/contants.dart
+++ b/packages/helium_flutter/lib/core/const/contants.dart
@@ -46,3 +46,4 @@ const String createPaddlePortalSessionMethodName = 'createPaddlePortalSession';
 const String resetStripeEntitlementsMethodName = 'resetStripeEntitlements';
 const String resetPaddleEntitlementsMethodName = 'resetPaddleEntitlements';
 const String handleURLMethodName = 'handleURL';
+const String setLogLevelMethodName = 'setLogLevel';

--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -682,10 +682,11 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
 
   @override
   void setLogLevel(HeliumLogLevel level) {
-    methodChannel.invokeMethod<void>(
-      setLogLevelMethodName,
-      level.rawValue,
-    );
+    methodChannel
+        .invokeMethod<void>(setLogLevelMethodName, level.rawValue)
+        .catchError((Object e) {
+      log('[Helium] Failed to set log level: $e');
+    });
   }
 
   @override

--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -681,6 +681,14 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
   }
 
   @override
+  void setLogLevel(HeliumLogLevel level) {
+    methodChannel.invokeMethod<void>(
+      setLogLevelMethodName,
+      level.rawValue,
+    );
+  }
+
+  @override
   Future<bool> handleURL(String url) async {
     if (!Platform.isIOS) {
       return false;

--- a/packages/helium_flutter/lib/core/helium_flutter_platform.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_platform.dart
@@ -3,6 +3,7 @@ import 'package:helium_flutter/core/helium_callbacks.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import '../types/experiment_info.dart';
+import '../types/helium_log_level.dart';
 import '../types/helium_types.dart';
 import '../types/helium_environment.dart';
 import 'helium_flutter_method_channel.dart';
@@ -178,4 +179,7 @@ abstract class HeliumFlutterPlatform extends PlatformInterface {
   ///
   /// iOS only; returns `false` on Android.
   Future<bool> handleURL(String url);
+
+  /// Set the log level on the underlying native Helium SDKs.
+  void setLogLevel(HeliumLogLevel level);
 }

--- a/packages/helium_flutter/lib/helium_flutter.dart
+++ b/packages/helium_flutter/lib/helium_flutter.dart
@@ -359,17 +359,14 @@ class HeliumFlutter {
   Future<void> resetPaddleEntitlements() =>
       HeliumFlutterPlatform.instance.resetPaddleEntitlements();
 
-  /// Sets the log level for the underlying native Helium SDKs.
+  /// Sets the log level for Helium logs.
   ///
-  /// Affects both iOS and Android. Safe to call before or after
-  /// [initialize]; the level is preserved across re-initializations.
+  /// Safe to call before or after [initialize]; the level is
+  /// preserved across re-initializations.
   ///
-  /// If never called, the native SDKs use their built-in defaults:
+  /// If never called, default level is:
   /// - Debug builds: [HeliumLogLevel.info]
   /// - Release builds: [HeliumLogLevel.error]
-  ///
-  /// Note: the iOS native SDK distinguishes `DEBUG` vs release at compile
-  /// time, while Android distinguishes via the host app's debuggable flag.
   void setLogLevel(HeliumLogLevel level) =>
       HeliumFlutterPlatform.instance.setLogLevel(level);
 

--- a/packages/helium_flutter/lib/helium_flutter.dart
+++ b/packages/helium_flutter/lib/helium_flutter.dart
@@ -5,9 +5,11 @@ import 'package:helium_flutter/core/helium_flutter_platform.dart';
 import 'package:helium_flutter/types/experiment_info.dart';
 import 'package:helium_flutter/types/helium_config_status.dart';
 import 'package:helium_flutter/types/helium_environment.dart';
+import 'package:helium_flutter/types/helium_log_level.dart';
 import 'package:helium_flutter/types/helium_types.dart';
 export './core/helium_callbacks.dart';
 export './types/experiment_info.dart';
+export './types/helium_log_level.dart';
 export './types/helium_transaction_status.dart';
 export './types/helium_types.dart';
 
@@ -356,6 +358,20 @@ class HeliumFlutter {
   /// Currently only supported on iOS; a no-op on Android.
   Future<void> resetPaddleEntitlements() =>
       HeliumFlutterPlatform.instance.resetPaddleEntitlements();
+
+  /// Sets the log level for the underlying native Helium SDKs.
+  ///
+  /// Affects both iOS and Android. Safe to call before or after
+  /// [initialize]; the level is preserved across re-initializations.
+  ///
+  /// If never called, the native SDKs use their built-in defaults:
+  /// - Debug builds: [HeliumLogLevel.info]
+  /// - Release builds: [HeliumLogLevel.error]
+  ///
+  /// Note: the iOS native SDK distinguishes `DEBUG` vs release at compile
+  /// time, while Android distinguishes via the host app's debuggable flag.
+  void setLogLevel(HeliumLogLevel level) =>
+      HeliumFlutterPlatform.instance.setLogLevel(level);
 
   /// Forward an incoming URL to Helium so it can react to External Web
   /// Checkout success/cancel redirects without waiting for the app to

--- a/packages/helium_flutter/lib/types/helium_log_level.dart
+++ b/packages/helium_flutter/lib/types/helium_log_level.dart
@@ -1,0 +1,26 @@
+/// Log levels supported by the underlying native Helium SDKs.
+///
+/// Setting a level emits log events at that level and all *less verbose*
+/// levels. For example:
+/// - [HeliumLogLevel.warn] emits warn + error
+/// - [HeliumLogLevel.debug] emits debug + info + warn + error
+///
+/// Defaults applied by the native SDKs when no level is set explicitly:
+/// - Debug builds: [HeliumLogLevel.info]
+/// - Release builds: [HeliumLogLevel.error]
+enum HeliumLogLevel {
+  off(0),
+  error(1),
+  warn(2),
+  info(3),
+  debug(4),
+
+  /// Most verbose level. Maps to `trace` on iOS and `verbose` on Android.
+  trace(5);
+
+  const HeliumLogLevel(this.rawValue);
+
+  /// Integer value forwarded across the platform channel. Matches the raw
+  /// values of `HeliumLogLevel` on both iOS and Android.
+  final int rawValue;
+}

--- a/packages/helium_flutter/lib/types/helium_log_level.dart
+++ b/packages/helium_flutter/lib/types/helium_log_level.dart
@@ -1,21 +1,15 @@
-/// Log levels supported by the underlying native Helium SDKs.
+/// Helium log levels.
 ///
 /// Setting a level emits log events at that level and all *less verbose*
 /// levels. For example:
 /// - [HeliumLogLevel.warn] emits warn + error
 /// - [HeliumLogLevel.debug] emits debug + info + warn + error
-///
-/// Defaults applied by the native SDKs when no level is set explicitly:
-/// - Debug builds: [HeliumLogLevel.info]
-/// - Release builds: [HeliumLogLevel.error]
 enum HeliumLogLevel {
   off(0),
   error(1),
   warn(2),
   info(3),
   debug(4),
-
-  /// Most verbose level. Maps to `trace` on iOS and `verbose` on Android.
   trace(5);
 
   const HeliumLogLevel(this.rawValue);

--- a/packages/helium_flutter/test/helium_flutter_test.dart
+++ b/packages/helium_flutter/test/helium_flutter_test.dart
@@ -198,6 +198,9 @@ class MockHeliumFlutterPlatform
 
   @override
   Future<bool> handleURL(String url) async => false;
+
+  @override
+  void setLogLevel(HeliumLogLevel level) {}
 }
 
 void main() {
@@ -359,5 +362,10 @@ void main() {
       await heliumFlutterPlugin.handleURL('https://example.com/success'),
       false,
     );
+  });
+  test(setLogLevelMethodName, () {
+    for (final level in HeliumLogLevel.values) {
+      heliumFlutterPlugin.setLogLevel(level);
+    }
   });
 }

--- a/packages/helium_stripe/test/helium_stripe_test.dart
+++ b/packages/helium_stripe/test/helium_stripe_test.dart
@@ -166,6 +166,8 @@ class MockHeliumFlutterPlatform
   Future<void> resetStripeEntitlements() async {}
   @override
   Future<void> resetPaddleEntitlements() async {}
+  @override
+  void setLogLevel(HeliumLogLevel level) {}
 }
 
 void main() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches platform-channel plumbing and native initialization/log forwarding behavior on both Android and iOS; mistakes could cause missing logs or runtime method-call errors but no auth/data-path logic changes.
> 
> **Overview**
> Adds a new Flutter API `setLogLevel(HeliumLogLevel)` (with shared enum + method-channel constant) and wires it through the platform interface and method-channel implementation.
> 
> Implements native handlers for `setLogLevel` on **Android and iOS** to update `Helium.config.logLevel`, and updates Android’s `BridgingLogger` to **filter forwarded log events by the configured level** while preserving the current level when swapping in the bridging logger during `setupCore`/re-init.
> 
> Updates tests/mocks in `helium_flutter` and `helium_stripe` to include the new platform method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1cce9c1db32f79d962465dbd57a28e7aff7a94c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to set the native SDK log level (off, error, warn, info, debug, trace) and platform-channel support to propagate it to native code.
  * Log forwarding now respects the configured log level so only messages at or above the selected severity are emitted.

* **Tests**
  * Added tests and updated mocks to cover the new setLogLevel behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->