### PR TITLE
[HEL-4856] | Flutter | canPresentUpsell() lacks defensive error handling

### DIFF
--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -851,6 +851,12 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
     Map<String, dynamic>? customPaywallTraits,
     required Widget paywallNotShownReplacement,
   }) {
+    // No native view exists on platforms other than iOS/Android; bypass the
+    // availability check so UpsellViewForTrigger's unsupported-platform
+    // message surfaces instead of silently rendering paywallNotShownReplacement.
+    if (!Platform.isIOS && !Platform.isAndroid) {
+      return UpsellViewForTrigger(trigger: trigger);
+    }
     _currentEventHandlers = eventHandlers;
     return UpsellWrapperWidget(
       trigger: trigger,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small platform-guard change that only affects `getUpsellWidget` behavior on non-iOS/Android targets.
> 
> **Overview**
> On non-iOS/Android platforms, `getUpsellWidget` now returns `UpsellViewForTrigger` directly instead of running the embedded availability check and falling back to `paywallNotShownReplacement`.
> 
> This ensures the widget surfaces the explicit unsupported-platform message rather than silently rendering the replacement content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce6b14eb9018d975c52becc3749f38dc4f434fba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated upsell widget display for non-iOS and Android platforms to show a platform compatibility message instead of a fallback widget.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudcaptainai/helium_flutter/pull/94)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->