### PR TITLE
HEL-6246 Update native SDKs to iOS 4.5.5 / Android 4.4.7 and bridge new APIs

### DIFF
--- a/example/lib/presentation/home_page.dart
+++ b/example/lib/presentation/home_page.dart
@@ -59,14 +59,14 @@ class _HomePageState extends State<HomePage> {
     setState(() => _anonymousId = null);
   }
 
-  Future<void> _openPaddlePortal() async {
-    final url = await _heliumFlutterPlugin.createPaddlePortalSession();
+  Future<void> _getPaddleCustomerId() async {
+    final customerId = await _heliumFlutterPlugin.getPaddleCustomerId();
     if (!mounted) return;
     showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Paddle Portal'),
-        content: SelectableText(url ?? 'No URL returned'),
+        title: const Text('Paddle Customer ID'),
+        content: SelectableText(customerId ?? 'No customer ID assigned'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
@@ -197,8 +197,8 @@ class _HomePageState extends State<HomePage> {
                 },
               ),
               _ActionButton(
-                label: 'Open Paddle Portal',
-                onPressed: _openPaddlePortal,
+                label: 'Get Paddle Customer ID',
+                onPressed: _getPaddleCustomerId,
               ),
             ],
           ),

--- a/packages/helium_flutter/CHANGELOG.md
+++ b/packages/helium_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.3.5
+- Updated helium-swift dependency to 4.5.5 and Helium Android dependency to 4.4.7
+- Added `getPaddleCustomerId()` and deprecated `createPaddlePortalSession()`. Fetch the Paddle customer ID and pass it to your server to generate a portal session. iOS only.
+- Added `setPaywallPreviewsEnabledInDevBuilds(bool)` to toggle the triple-tap paywall previews gesture in dev builds.
+- Added `HeliumFlutter().testing` overrides (`setPurchaseResult`, `setRestoreResult`, `setIntroOfferEligibility`, `reset`) for stubbing purchase/restore flows in automated tests.
+
 ## 3.3.4
 - Updated helium-swift dependency to 4.4.8
 - **Breaking:** `handleURL(String url)` now returns `Future<HeliumCheckoutRedirectType?>` instead of `Future<bool>`. Returns the matched redirect type (`success` / `cancel`) when the URL is a Helium checkout redirect, otherwise `null`.

--- a/packages/helium_flutter/android/build.gradle
+++ b/packages/helium_flutter/android/build.gradle
@@ -48,7 +48,7 @@ android {
     }
 
     dependencies {
-        implementation("com.tryhelium.paywall:core:4.4.3")
+        implementation("com.tryhelium.paywall:core:4.4.7")
         implementation("com.google.code.gson:gson:2.10.1")
         implementation("com.android.billingclient:billing:8.0.0")
         testImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
+++ b/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
@@ -426,6 +426,7 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       "setAllowWebCheckoutWithoutUserId",
       "createStripePortalSession",
       "createPaddlePortalSession",
+      "getPaddleCustomerId",
       "resetStripeEntitlements",
       "resetPaddleEntitlements" -> {
         // Web Checkout (Stripe/Paddle) is not yet supported on Android.
@@ -451,6 +452,43 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
           Helium.config.logLevel = level
           result.success(null)
         }
+      }
+      "setPaywallPreviewsEnabledInDevBuilds" -> {
+        val enabled = call.arguments as? Boolean ?: true
+        Helium.config.enablePaywallPreviewsInDevBuilds = enabled
+        result.success(null)
+      }
+      "setTestPurchaseResult" -> {
+        val resultString = call.arguments as? String ?: ""
+        val status: HeliumPaywallTransactionStatus = when (resultString.lowercase()) {
+          "purchased" -> HeliumPaywallTransactionStatus.Purchased
+          "cancelled" -> HeliumPaywallTransactionStatus.Cancelled
+          // Android SDK has no Restored status; treat it as Purchased.
+          "restored" -> HeliumPaywallTransactionStatus.Purchased
+          "pending" -> HeliumPaywallTransactionStatus.Pending
+          "failed" -> HeliumPaywallTransactionStatus.Failed(Exception("Stubbed test failure."))
+          else -> {
+            android.util.Log.w("HeliumPaywallSdk", "setTestPurchaseResult: unknown result '$resultString', ignoring")
+            result.success(null)
+            return
+          }
+        }
+        Helium.testing.purchaseHandler = { _ -> status }
+        result.success(null)
+      }
+      "setTestRestoreResult" -> {
+        val success = call.arguments as? Boolean ?: false
+        Helium.testing.restoreHandler = { success }
+        result.success(null)
+      }
+      "setTestIntroOfferEligibility" -> {
+        val eligible = call.arguments as? Boolean ?: false
+        Helium.testing.introOfferEligibility = { _ -> eligible }
+        result.success(null)
+      }
+      "resetTesting" -> {
+        Helium.testing.reset()
+        result.success(null)
       }
       else -> {
         result.notImplemented()

--- a/packages/helium_flutter/ios/helium_flutter.podspec
+++ b/packages/helium_flutter/ios/helium_flutter.podspec
@@ -20,7 +20,7 @@ A Flutter plugin that integrates the Helium SDK for iOS.
   s.dependency 'Flutter'
 
   # note that the dependency in Package.swift is what's actually used... we might be able to remove this but safer to keep in for now
-  s.dependency 'Helium', '4.4.8'
+  s.dependency 'Helium', '4.5.5'
 
   s.platform = :ios, '15.0'
 

--- a/packages/helium_flutter/ios/helium_flutter/Package.swift
+++ b/packages/helium_flutter/ios/helium_flutter/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "helium-flutter", targets: ["helium_flutter"])
     ],
     dependencies: [
-    .package(url: "https://github.com/cloudcaptainai/helium-swift.git", exact: "4.4.8")],
+    .package(url: "https://github.com/cloudcaptainai/helium-swift.git", exact: "4.5.5")],
     targets: [
         .target(
             name: "helium_flutter",

--- a/packages/helium_flutter/ios/helium_flutter/Sources/helium_flutter/HeliumFlutterPlugin.swift
+++ b/packages/helium_flutter/ios/helium_flutter/Sources/helium_flutter/HeliumFlutterPlugin.swift
@@ -264,6 +264,11 @@ public class HeliumFlutterPlugin: NSObject, FlutterPlugin {
                     }
                 }
             }
+        case "getPaddleCustomerId":
+            Task {
+                let customerId = await Helium.shared.getPaddleCustomerId()
+                DispatchQueue.main.async { result(customerId) }
+            }
         case "resetStripeEntitlements":
             Helium.shared.resetStripeEntitlements()
             result(nil)
@@ -278,9 +283,46 @@ public class HeliumFlutterPlugin: NSObject, FlutterPlugin {
             }
             Helium.config.logLevel = level
             result(nil)
+        case "setPaywallPreviewsEnabledInDevBuilds":
+            let enabled = call.arguments as? Bool ?? true
+            Helium.config.paywallPreviewsAutoEnabledInDevBuilds = enabled
+            result(nil)
+        case "setTestPurchaseResult":
+            guard let resultString = call.arguments as? String else {
+                result(FlutterError(code: "BAD_ARGS", message: "result not provided", details: nil))
+                return
+            }
+            setTestPurchaseResult(resultString)
+            result(nil)
+        case "setTestRestoreResult":
+            let success = call.arguments as? Bool ?? false
+            Helium.testing.restoreHandler = { success }
+            result(nil)
+        case "setTestIntroOfferEligibility":
+            let eligible = call.arguments as? Bool ?? false
+            Helium.testing.introOfferEligibility = { _ in eligible }
+            result(nil)
+        case "resetTesting":
+            Helium.testing.reset()
+            result(nil)
         default:
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    private func setTestPurchaseResult(_ resultString: String) {
+        let status: HeliumPaywallTransactionStatus
+        switch resultString.lowercased() {
+        case "purchased": status = .purchased
+        case "cancelled": status = .cancelled
+        case "restored": status = .restored
+        case "pending": status = .pending
+        case "failed": status = .failed(PurchaseError.purchaseFailed(errorMsg: "Stubbed test failure."))
+        default:
+            print("[Helium] setTestPurchaseResult: unknown result '\(resultString)', ignoring")
+            return
+        }
+        Helium.testing.purchaseHandler = { _ in status }
     }
 
     private func parseWebCheckoutProcessors(_ names: [String]?) -> WebCheckoutProcessors {

--- a/packages/helium_flutter/lib/core/const/contants.dart
+++ b/packages/helium_flutter/lib/core/const/contants.dart
@@ -1,5 +1,5 @@
 // SDK version - keep in sync with pubspec.yaml
-const String heliumFlutterSdkVersion = '3.3.4';
+const String heliumFlutterSdkVersion = '3.3.5';
 
 //Native view type
 const String upsellViewForTrigger = 'upsellViewForTrigger';
@@ -43,7 +43,15 @@ const String hasActiveStripeEntitlementMethodName = 'hasActiveStripeEntitlement'
 const String hasActivePaddleEntitlementMethodName = 'hasActivePaddleEntitlement';
 const String createStripePortalSessionMethodName = 'createStripePortalSession';
 const String createPaddlePortalSessionMethodName = 'createPaddlePortalSession';
+const String getPaddleCustomerIdMethodName = 'getPaddleCustomerId';
 const String resetStripeEntitlementsMethodName = 'resetStripeEntitlements';
 const String resetPaddleEntitlementsMethodName = 'resetPaddleEntitlements';
 const String handleURLMethodName = 'handleURL';
 const String setLogLevelMethodName = 'setLogLevel';
+const String setPaywallPreviewsEnabledInDevBuildsMethodName = 'setPaywallPreviewsEnabledInDevBuilds';
+
+//Testing override method names
+const String setTestPurchaseResultMethodName = 'setTestPurchaseResult';
+const String setTestRestoreResultMethodName = 'setTestRestoreResult';
+const String setTestIntroOfferEligibilityMethodName = 'setTestIntroOfferEligibility';
+const String resetTestingMethodName = 'resetTesting';

--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -649,6 +649,7 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
   }
 
   @override
+  @Deprecated('Use getPaddleCustomerId instead.')
   Future<String?> createPaddlePortalSession() async {
     if (!Platform.isIOS) {
       log('[Helium] createPaddlePortalSession is only available on iOS');
@@ -660,6 +661,22 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
       );
     } on PlatformException catch (e) {
       log('[Helium] Failed to create Paddle portal session: ${e.message}');
+      return null;
+    }
+  }
+
+  @override
+  Future<String?> getPaddleCustomerId() async {
+    if (!Platform.isIOS) {
+      log('[Helium] getPaddleCustomerId is only available on iOS');
+      return null;
+    }
+    try {
+      return await methodChannel.invokeMethod<String>(
+        getPaddleCustomerIdMethodName,
+      );
+    } on PlatformException catch (e) {
+      log('[Helium] Failed to get Paddle customer ID: ${e.message}');
       return null;
     }
   }
@@ -714,6 +731,52 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
       log('[Helium] Failed to handle URL: ${e.message}');
       return null;
     }
+  }
+
+  @override
+  void setPaywallPreviewsEnabledInDevBuilds(bool enabled) {
+    methodChannel
+        .invokeMethod<void>(
+            setPaywallPreviewsEnabledInDevBuildsMethodName, enabled)
+        .catchError((Object e) {
+      log('[Helium] Failed to set paywall previews enabled: $e');
+    });
+  }
+
+  @override
+  void setTestPurchaseResult(HeliumTransactionStatus result) {
+    methodChannel
+        .invokeMethod<void>(setTestPurchaseResultMethodName, result.name)
+        .catchError((Object e) {
+      log('[Helium] Failed to set test purchase result: $e');
+    });
+  }
+
+  @override
+  void setTestRestoreResult(bool success) {
+    methodChannel
+        .invokeMethod<void>(setTestRestoreResultMethodName, success)
+        .catchError((Object e) {
+      log('[Helium] Failed to set test restore result: $e');
+    });
+  }
+
+  @override
+  void setTestIntroOfferEligibility(bool eligible) {
+    methodChannel
+        .invokeMethod<void>(setTestIntroOfferEligibilityMethodName, eligible)
+        .catchError((Object e) {
+      log('[Helium] Failed to set test intro offer eligibility: $e');
+    });
+  }
+
+  @override
+  void resetTesting() {
+    methodChannel
+        .invokeMethod<void>(resetTestingMethodName)
+        .catchError((Object e) {
+      log('[Helium] Failed to reset testing overrides: $e');
+    });
   }
 
   void _handlePaywallEventHandlers(HeliumPaywallEvent event) {

--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -675,8 +675,8 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
       return await methodChannel.invokeMethod<String>(
         getPaddleCustomerIdMethodName,
       );
-    } on PlatformException catch (e) {
-      log('[Helium] Failed to get Paddle customer ID: ${e.message}');
+    } catch (e) {
+      log('[Helium] Failed to get Paddle customer ID: $e');
       return null;
     }
   }

--- a/packages/helium_flutter/lib/core/helium_flutter_platform.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_platform.dart
@@ -4,6 +4,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import '../types/experiment_info.dart';
 import '../types/helium_log_level.dart';
+import '../types/helium_transaction_status.dart';
 import '../types/helium_types.dart';
 import '../types/helium_environment.dart';
 import 'helium_flutter_method_channel.dart';
@@ -164,7 +165,12 @@ abstract class HeliumFlutterPlatform extends PlatformInterface {
 
   /// Creates a Paddle customer portal session and returns the portal URL.
   /// iOS only; returns `null` on Android.
+  @Deprecated('Use getPaddleCustomerId instead.')
   Future<String?> createPaddlePortalSession();
+
+  /// Returns the Paddle customer ID for the current user.
+  /// iOS only; returns `null` on Android.
+  Future<String?> getPaddleCustomerId();
 
   /// Resets Stripe entitlements and clears the user ID.
   /// iOS only; no-op on Android.
@@ -178,4 +184,19 @@ abstract class HeliumFlutterPlatform extends PlatformInterface {
 
   /// Set the log level on the underlying native Helium SDKs.
   void setLogLevel(HeliumLogLevel level);
+
+  /// Enable/disable the triple-tap paywall previews gesture in dev builds.
+  void setPaywallPreviewsEnabledInDevBuilds(bool enabled);
+
+  /// Stub purchase attempts with the given result for automated testing.
+  void setTestPurchaseResult(HeliumTransactionStatus result);
+
+  /// Stub restore attempts with the given result for automated testing.
+  void setTestRestoreResult(bool success);
+
+  /// Override intro-offer eligibility for every product for automated testing.
+  void setTestIntroOfferEligibility(bool eligible);
+
+  /// Clear all configured test override handlers.
+  void resetTesting();
 }

--- a/packages/helium_flutter/lib/helium_flutter.dart
+++ b/packages/helium_flutter/lib/helium_flutter.dart
@@ -6,6 +6,7 @@ import 'package:helium_flutter/types/experiment_info.dart';
 import 'package:helium_flutter/types/helium_config_status.dart';
 import 'package:helium_flutter/types/helium_environment.dart';
 import 'package:helium_flutter/types/helium_log_level.dart';
+import 'package:helium_flutter/types/helium_transaction_status.dart';
 import 'package:helium_flutter/types/helium_types.dart';
 export './core/helium_callbacks.dart';
 export './types/experiment_info.dart';
@@ -340,8 +341,21 @@ class HeliumFlutter {
   /// Returns `null` if the session could not be created (e.g. the user has
   /// no Paddle customer ID yet, or the request failed). Currently only
   /// supported on iOS; returns `null` on Android.
+  @Deprecated('Use getPaddleCustomerId() and pass the ID to your server to '
+      'generate a Paddle customer portal session instead.')
   Future<String?> createPaddlePortalSession() =>
+      // ignore: deprecated_member_use_from_same_package
       HeliumFlutterPlatform.instance.createPaddlePortalSession();
+
+  /// Returns the Paddle customer ID for the current user, if one exists.
+  ///
+  /// Pass this ID to your server to generate a Paddle customer portal session,
+  /// allowing the user to manage their subscriptions.
+  ///
+  /// Returns `null` if none has been assigned. Currently only supported on
+  /// iOS; returns `null` on Android.
+  Future<String?> getPaddleCustomerId() =>
+      HeliumFlutterPlatform.instance.getPaddleCustomerId();
 
   /// Resets Stripe entitlements and clears the user ID. Call this to
   /// effectively "log out" a Stripe user if your app supports multiple Stripe
@@ -387,4 +401,49 @@ class HeliumFlutter {
   /// Currently only supported on iOS; always returns `null` on Android.
   Future<HeliumCheckoutRedirectType?> handleURL(String url) =>
       HeliumFlutterPlatform.instance.handleURL(url);
+
+  /// Controls whether the triple-tap paywall previews gesture is enabled in
+  /// dev builds (DEBUG / TestFlight on iOS, debug builds on Android).
+  ///
+  /// Defaults to `true`.
+  void setPaywallPreviewsEnabledInDevBuilds(bool enabled) =>
+      HeliumFlutterPlatform.instance
+          .setPaywallPreviewsEnabledInDevBuilds(enabled);
+
+  /// Overrides for automated testing (UI tests, CI) where StoreKit / Play
+  /// Billing configuration is awkward.
+  ///
+  /// Gate these calls behind a build-env flag so they never run in production
+  /// builds. The native SDK also ignores test handlers when it detects a
+  /// production environment, but do not rely on that safety net.
+  HeliumTesting get testing => const HeliumTesting();
+}
+
+/// Test-only overrides for stubbing purchase, restore, and intro-offer
+/// eligibility flows. Access via [HeliumFlutter.testing].
+class HeliumTesting {
+  const HeliumTesting();
+
+  /// Stubs purchase attempts to return [result] instead of running the real
+  /// StoreKit / Play Billing flow. Applies to every product ID.
+  void setPurchaseResult(HeliumTransactionStatus result) =>
+      HeliumFlutterPlatform.instance.setTestPurchaseResult(result);
+
+  /// Stubs restore attempts to return [success] instead of running the real
+  /// restore flow.
+  void setRestoreResult(bool success) =>
+      HeliumFlutterPlatform.instance.setTestRestoreResult(success);
+
+  /// Overrides the intro-offer eligibility check for every product. Useful
+  /// for testing the "no trial offer" UI branch.
+  ///
+  /// Eligibility is read during config fetch and cached, so call this before
+  /// [HeliumFlutter.initialize] for the initial paywall render to reflect the
+  /// override.
+  void setIntroOfferEligibility(bool eligible) =>
+      HeliumFlutterPlatform.instance.setTestIntroOfferEligibility(eligible);
+
+  /// Clears all configured test handlers. The native SDK falls back to the
+  /// real purchase/restore flows.
+  void reset() => HeliumFlutterPlatform.instance.resetTesting();
 }

--- a/packages/helium_flutter/pubspec.yaml
+++ b/packages/helium_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: helium_flutter
 description: "Flutter Paywall SDK for Helium. Remotely build and auto-optimize paywalls (tryhelium.com)"
 
 # Remember to update CHANGELOG.md when releasing a new version!!! (see CONTRIBUTING.md)
-version: 3.3.4
+version: 3.3.5
 
 homepage: https://tryhelium.com
 license: MIT

--- a/packages/helium_flutter/test/helium_flutter_test.dart
+++ b/packages/helium_flutter/test/helium_flutter_test.dart
@@ -192,6 +192,9 @@ class MockHeliumFlutterPlatform
   Future<String?> createPaddlePortalSession() async => null;
 
   @override
+  Future<String?> getPaddleCustomerId() async => null;
+
+  @override
   Future<void> resetStripeEntitlements() async {}
 
   @override
@@ -202,6 +205,21 @@ class MockHeliumFlutterPlatform
 
   @override
   void setLogLevel(HeliumLogLevel level) {}
+
+  @override
+  void setPaywallPreviewsEnabledInDevBuilds(bool enabled) {}
+
+  @override
+  void setTestPurchaseResult(HeliumTransactionStatus result) {}
+
+  @override
+  void setTestRestoreResult(bool success) {}
+
+  @override
+  void setTestIntroOfferEligibility(bool eligible) {}
+
+  @override
+  void resetTesting() {}
 }
 
 void main() {
@@ -350,7 +368,11 @@ void main() {
     );
   });
   test(createPaddlePortalSessionMethodName, () async {
+    // ignore: deprecated_member_use_from_same_package
     expect(await heliumFlutterPlugin.createPaddlePortalSession(), isNull);
+  });
+  test(getPaddleCustomerIdMethodName, () async {
+    expect(await heliumFlutterPlugin.getPaddleCustomerId(), isNull);
   });
   test(resetStripeEntitlementsMethodName, () async {
     await heliumFlutterPlugin.resetStripeEntitlements();
@@ -368,5 +390,17 @@ void main() {
     for (final level in HeliumLogLevel.values) {
       heliumFlutterPlugin.setLogLevel(level);
     }
+  });
+  test(setPaywallPreviewsEnabledInDevBuildsMethodName, () {
+    heliumFlutterPlugin.setPaywallPreviewsEnabledInDevBuilds(true);
+    heliumFlutterPlugin.setPaywallPreviewsEnabledInDevBuilds(false);
+  });
+  test('testing overrides', () {
+    for (final status in HeliumTransactionStatus.values) {
+      heliumFlutterPlugin.testing.setPurchaseResult(status);
+    }
+    heliumFlutterPlugin.testing.setRestoreResult(true);
+    heliumFlutterPlugin.testing.setIntroOfferEligibility(false);
+    heliumFlutterPlugin.testing.reset();
   });
 }

--- a/packages/helium_revenuecat/CHANGELOG.md
+++ b/packages/helium_revenuecat/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.5
+- Updated helium-swift dependency to 4.5.5 and Helium Android dependency to 4.4.7
+
 ## 3.3.4
 - Updated helium-swift dependency to 4.4.8
 

--- a/packages/helium_revenuecat/pubspec.yaml
+++ b/packages/helium_revenuecat/pubspec.yaml
@@ -1,6 +1,6 @@
 name: helium_revenuecat
 description: "Helium RevenueCat SDK. Remotely build and auto-optimize paywalls (tryhelium.com)"
-version: 3.3.4
+version: 3.3.5
 homepage: https://tryhelium.com
 
 environment:

--- a/packages/helium_stripe/test/helium_stripe_test.dart
+++ b/packages/helium_stripe/test/helium_stripe_test.dart
@@ -143,17 +143,19 @@ class MockHeliumFlutterPlatform
   @override
   void setRevenueCatAppUserId(String rcAppUserId) {}
   @override
+  Future<void> setThirdPartyAnalyticsAnonymousId(String? anonymousId) async {}
+  @override
   void setAndroidConsumableProductIds(Set<String> productIds) {}
   @override
-  void enableExternalWebCheckout({
+  Future<void> enableExternalWebCheckout({
     required String successURL,
     required String cancelURL,
     Set<HeliumWebCheckoutProcessor>? paymentProcessors,
-  }) {}
+  }) async {}
   @override
-  void disableExternalWebCheckout() {}
+  Future<void> disableExternalWebCheckout() async {}
   @override
-  void setAllowWebCheckoutWithoutUserId(bool allow) {}
+  Future<void> setAllowWebCheckoutWithoutUserId(bool allow) async {}
   @override
   Future<bool> hasActiveStripeEntitlement() async => false;
   @override
@@ -164,11 +166,25 @@ class MockHeliumFlutterPlatform
   @override
   Future<String?> createPaddlePortalSession() async => null;
   @override
+  Future<String?> getPaddleCustomerId() async => null;
+  @override
   Future<void> resetStripeEntitlements() async {}
   @override
   Future<void> resetPaddleEntitlements() async {}
   @override
   void setLogLevel(HeliumLogLevel level) {}
+  @override
+  Future<HeliumCheckoutRedirectType?> handleURL(String url) async => null;
+  @override
+  void setPaywallPreviewsEnabledInDevBuilds(bool enabled) {}
+  @override
+  void setTestPurchaseResult(HeliumTransactionStatus result) {}
+  @override
+  void setTestRestoreResult(bool success) {}
+  @override
+  void setTestIntroOfferEligibility(bool eligible) {}
+  @override
+  void resetTesting() {}
 }
 
 void main() {


### PR DESCRIPTION
## Summary

Updates the native SDK dependencies to the latest releases and bridges the API changes worth uptaking over this range. Modeled on the Expo SDK, which is ahead of us — the open auto-generated version-bump PRs (#98–#104) were pure version strings, so this consolidates the bump with the actual API surface changes.

- **iOS** `helium-swift` 4.4.8 → **4.5.5** (`Package.swift`, `podspec`)
- **Android** `com.tryhelium.paywall:core` 4.4.3 → **4.4.7** (`build.gradle`)
- Flutter SDK `3.3.4` → **3.3.5** (`pubspec.yaml` ×2, `contants.dart`, CHANGELOGs)

## New / changed API

Everything else in the 4.4.9→4.5.5 iOS notes is internal (Paddle discounts, crash/race fixes, language targeting, refactors) — nothing else bridgeable, consistent with what Expo skipped.

1. **`getPaddleCustomerId()`** added; **`createPaddlePortalSession()`** deprecated. iOS calls `Helium.shared.getPaddleCustomerId()`; Android returns `null` (no native equivalent). Fetch the ID and pass it to your server to generate a portal session. (iOS SDK 4.5.4 / HEL-6133)
2. **`setPaywallPreviewsEnabledInDevBuilds(bool)`** — toggles the triple-tap paywall previews gesture in dev builds. iOS `Helium.config.paywallPreviewsAutoEnabledInDevBuilds`, Android `Helium.config.enablePaywallPreviewsInDevBuilds`. (iOS SDK 4.4.9)
3. **`HeliumFlutter().testing`** grouped getter → `HeliumTesting` with `setPurchaseResult` / `setRestoreResult` / `setIntroOfferEligibility` / `reset`, backed by `Helium.testing.*` on both platforms (Android maps the absent `restored` status to `Purchased`). For stubbing purchase/restore flows in automated tests. (iOS SDK 4.5.0)

Each threaded through public API → platform interface → method channel → constants → iOS → Android → mocks/tests. The example app's Paddle button now demonstrates `getPaddleCustomerId()`.

## Also

Resynced the stale `helium_stripe` test mock with `HeliumFlutterPlatform` — it was missing `handleURL` / `setThirdPartyAnalyticsAnonymousId` and declared three web-checkout methods as `void` instead of `Future<void>`, so that package's tests wouldn't compile before this change.

## Testing

- `helium_flutter`: `flutter analyze` clean, 37 tests pass (incl. new coverage for all three additions)
- `helium_stripe`: `flutter analyze` clean, 9 tests pass
- `helium_revenuecat`: `flutter analyze` clean, tests pass

Note: `flutter analyze`/`test` only exercise the Dart layer. The Swift/Kotlin bridge additions were modeled on Expo's bridge code and every native symbol was verified to exist in the tagged 4.5.5 / v4.4.7 releases, but a full native build of the example app on each platform has not been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription/Paddle flows via a deprecated portal API and native SDK version bumps; test purchase overrides affect billing paths but are intended for non-production use.
> 
> **Overview**
> Releases **helium_flutter 3.3.5** with native bumps (**helium-swift 4.5.5**, Android **4.4.7**) and wires new surface through Dart → method channel → iOS/Android.
> 
> **Paddle:** Adds **`getPaddleCustomerId()`** (iOS; Android returns `null`) and **deprecates `createPaddlePortalSession()`** so apps fetch the customer ID and create portal sessions on their server. The example app’s Paddle action now shows the customer ID instead of opening a portal URL.
> 
> **Dev / tests:** Adds **`setPaywallPreviewsEnabledInDevBuilds(bool)`** for the triple-tap paywall preview gesture, and **`HeliumFlutter().testing`** (`setPurchaseResult`, `setRestoreResult`, `setIntroOfferEligibility`, `reset`) backed by native `Helium.testing` handlers (Android maps `restored` to purchased).
> 
> Also bumps **helium_revenuecat** to 3.3.5 and fixes the **helium_stripe** test mock so it implements the updated `HeliumFlutterPlatform` (including async web-checkout methods and the new APIs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45b022b4a680438edf6ca8c326460e535b755662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS support for retrieving the Paddle Customer ID.
  * Added developer controls to enable paywall previews in dev builds and to stub test purchase, restore, and intro-offer eligibility outcomes.
* **Changes**
  * Deprecated Paddle portal session creation in favor of retrieving the Customer ID.
  * Updated the example app UI to show the “Get Paddle Customer ID” action in Extras.
* **Chores**
  * Released version 3.3.5 with updated native SDK support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->