### PR TITLE
Add onEntitled and onPaywallUnavailable callbacks to presentUpsell (3.3.6)

### DIFF
--- a/example/lib/presentation/home_page.dart
+++ b/example/lib/presentation/home_page.dart
@@ -166,6 +166,12 @@ class _HomePageState extends State<HomePage> {
                   await _heliumFlutterPlugin.presentUpsell(
                     trigger: _trigger,
                     context: context,
+                    onEntitled: () {
+                      debugPrint('[Helium] onEntitled');
+                    },
+                    onPaywallUnavailable: () {
+                      debugPrint('[Helium] onPaywallUnavailable');
+                    },
                   );
                 },
               ),

--- a/packages/helium_flutter/CHANGELOG.md
+++ b/packages/helium_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.6
+- Added `onEntitled` and `onPaywallUnavailable` callbacks to `presentUpsell`. `onEntitled` fires when the user becomes entitled (purchase, restore, or already-entitled skip when `dontShowIfAlreadyEntitled` is set); `onPaywallUnavailable` fires when neither the paywall nor fallback could be shown.
+
 ## 3.3.5
 - Updated helium-swift dependency to 4.5.5 and Helium Android dependency to 4.4.7
 - Added `getPaddleCustomerId()` and deprecated `createPaddlePortalSession()`. Fetch the Paddle customer ID and pass it to your server to generate a portal session. iOS only.

--- a/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
+++ b/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
@@ -203,9 +203,19 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
             customPaywallTraits = customPaywallTraits,
             dontShowIfAlreadyEntitled = dontShowIfAlreadyEntitled
           ),
+          onEntitled = {
+            Handler(Looper.getMainLooper()).post {
+              try {
+                channel.invokeMethod("onPaywallEntitled", null)
+              } catch (e: Exception) {
+                // Channel may be detached, ignore
+              }
+            }
+          },
           eventListener = eventListener,
           onPaywallNotShown = { _ ->
-            // nothing for now
+            // paywallNotShown handled Dart-side via the paywallOpenFailed event
+            // (see onPaywallUnavailable).
           }
         )
 

--- a/packages/helium_flutter/ios/helium_flutter/Sources/helium_flutter/HeliumFlutterPlugin.swift
+++ b/packages/helium_flutter/ios/helium_flutter/Sources/helium_flutter/HeliumFlutterPlugin.swift
@@ -423,9 +423,13 @@ public class HeliumFlutterPlugin: NSObject, FlutterPlugin {
                 onAnyEvent: { [weak self] event in
                     self?.channel.invokeMethod("onPaywallEventHandler", arguments: event.toDictionary())
                 }
-            )
+            ),
+            onEntitled: { [weak self] in
+                self?.channel.invokeMethod("onPaywallEntitled", arguments: nil)
+            }
         ) { _ in
-            // paywallNotShownReason callback - nothing for now
+            // paywallNotShownReason callback - handled Dart-side via the
+            // paywallOpenFailed event (see onPaywallUnavailable).
         }
     }
 

--- a/packages/helium_flutter/ios/helium_flutter/Sources/helium_flutter/HeliumFlutterPlugin.swift
+++ b/packages/helium_flutter/ios/helium_flutter/Sources/helium_flutter/HeliumFlutterPlugin.swift
@@ -467,7 +467,9 @@ public class HeliumFlutterPlugin: NSObject, FlutterPlugin {
                 }
             ),
             onEntitled: { [weak self] in
-                self?.channel.invokeMethod("onPaywallEntitled", arguments: nil)
+                DispatchQueue.main.async {
+                    self?.channel.invokeMethod("onPaywallEntitled", arguments: nil)
+                }
             }
         ) { _ in
             // paywallNotShownReason callback - handled Dart-side via the

--- a/packages/helium_flutter/lib/core/const/contants.dart
+++ b/packages/helium_flutter/lib/core/const/contants.dart
@@ -14,6 +14,7 @@ const String makePurchaseMethodName = 'makePurchase';
 const String restorePurchasesMethodName = 'restorePurchases';
 const String onPaywallEventMethodName = 'onPaywallEvent';
 const String onPaywallEventHandlerMethodName = 'onPaywallEventHandler';
+const String onPaywallEntitledMethodName = 'onPaywallEntitled';
 const String getHeliumUserIdMethodName = 'getHeliumUserId';
 const String hideUpsellMethodName = 'hideUpsell';
 const String overrideUserIdMethodName = 'overrideUserId';

--- a/packages/helium_flutter/lib/core/const/contants.dart
+++ b/packages/helium_flutter/lib/core/const/contants.dart
@@ -1,5 +1,5 @@
 // SDK version - keep in sync with pubspec.yaml
-const String heliumFlutterSdkVersion = '3.3.5';
+const String heliumFlutterSdkVersion = '3.3.6';
 
 //Native view type
 const String upsellViewForTrigger = 'upsellViewForTrigger';

--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -942,14 +942,15 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
         final unavailableReason = heliumPaywallEvent.paywallUnavailableReason;
         final onPaywallUnavailable = _currentOnPaywallUnavailable;
         _currentOnPaywallUnavailable = null;
-        if (trigger != null &&
-            unavailableReason != "alreadyPresented" &&
+        if (unavailableReason != "alreadyPresented" &&
             unavailableReason != "secondTryNoMatch") {
           _safeInvokeCallback(onPaywallUnavailable, 'onPaywallUnavailable');
-          // Dispatch on next frame to let event handling finish processing
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            _showFallbackSheet(trigger);
-          });
+          if (trigger != null) {
+            // Dispatch on next frame to let event handling finish processing
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              _showFallbackSheet(trigger);
+            });
+          }
         }
         break;
     }

--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -506,6 +506,8 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
     _isFallbackSheetShowing = false;
     _fallbackContext = null;
     _currentEventHandlers = null;
+    _currentOnEntitled = null;
+    _currentOnPaywallUnavailable = null;
     // Reset native SDK state
     try {
       await methodChannel.invokeMethod<void>(

--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -23,6 +23,9 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
   /// Callbacks for the current [presentUpsell] presentation. [_currentOnEntitled]
   /// is invoked from the native `onEntitled` closure (via the [onPaywallEntitledMethodName]
   /// method call); [_currentOnPaywallUnavailable] is derived from `paywallOpenFailed`.
+  ///
+  /// Both are one-shot: capture into a local and null the field before invoking,
+  /// so a callback that re-enters [presentUpsell] keeps its freshly stored handler.
   void Function()? _currentOnEntitled;
   void Function()? _currentOnPaywallUnavailable;
 
@@ -221,8 +224,9 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
             (args is Map) ? Map<String, dynamic>.from(args) : {};
         _handlePaywallEventHandlers(HeliumPaywallEvent.fromMap(eventDict));
       } else if (handler.method == onPaywallEntitledMethodName) {
-        _safeInvokeCallback(_currentOnEntitled, 'onEntitled');
+        final onEntitled = _currentOnEntitled;
         _currentOnEntitled = null;
+        _safeInvokeCallback(onEntitled, 'onEntitled');
       } else if (handler.method == onHeliumLogEventMethodName) {
         final dynamic args = handler.arguments;
         final Map<String, dynamic> eventMap =
@@ -934,17 +938,17 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
       case 'paywallOpenFailed':
         _currentEventHandlers = null;
         final unavailableReason = heliumPaywallEvent.paywallUnavailableReason;
+        final onPaywallUnavailable = _currentOnPaywallUnavailable;
+        _currentOnPaywallUnavailable = null;
         if (trigger != null &&
             unavailableReason != "alreadyPresented" &&
             unavailableReason != "secondTryNoMatch") {
-          _safeInvokeCallback(
-              _currentOnPaywallUnavailable, 'onPaywallUnavailable');
+          _safeInvokeCallback(onPaywallUnavailable, 'onPaywallUnavailable');
           // Dispatch on next frame to let event handling finish processing
           WidgetsBinding.instance.addPostFrameCallback((_) {
             _showFallbackSheet(trigger);
           });
         }
-        _currentOnPaywallUnavailable = null;
         break;
     }
   }

--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -221,11 +221,7 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
             (args is Map) ? Map<String, dynamic>.from(args) : {};
         _handlePaywallEventHandlers(HeliumPaywallEvent.fromMap(eventDict));
       } else if (handler.method == onPaywallEntitledMethodName) {
-        try {
-          _currentOnEntitled?.call();
-        } catch (e) {
-          log('[Helium] Error in onEntitled callback: $e');
-        }
+        _safeInvokeCallback(_currentOnEntitled, 'onEntitled');
         _currentOnEntitled = null;
       } else if (handler.method == onHeliumLogEventMethodName) {
         final dynamic args = handler.arguments;
@@ -361,20 +357,22 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
       _currentEventHandlers = null;
       _currentOnEntitled = null;
       _currentOnPaywallUnavailable = null;
-      await methodChannel.invokeMethod<String?>(
-        fallbackOpenEventMethodName,
-        {
-          'trigger': trigger,
-          'viewType': 'presented',
-          'paywallUnavailableReason': 'bridgingError',
-        },
-      );
-      _showFallbackSheet(trigger);
       try {
-        onPaywallUnavailable?.call();
+        await methodChannel.invokeMethod<String?>(
+          fallbackOpenEventMethodName,
+          {
+            'trigger': trigger,
+            'viewType': 'presented',
+            'paywallUnavailableReason': 'bridgingError',
+          },
+        );
       } catch (err) {
-        log('[Helium] Error in onPaywallUnavailable callback: $err');
+        log('[Helium] Failed to send fallback open event: $err');
       }
+      _showFallbackSheet(trigger);
+      // Helium paywall could not be shown; signal the caller regardless of
+      // whether the Flutter fallback view is displayed.
+      _safeInvokeCallback(onPaywallUnavailable, 'onPaywallUnavailable');
       return "Failed to present upsell: '${e.message}'.";
     }
   }
@@ -903,6 +901,17 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
     }
   }
 
+  /// Invokes a user-supplied callback, containing any exception so a throwing
+  /// callback can never crash the SDK.
+  void _safeInvokeCallback(void Function()? callback, String name) {
+    if (callback == null) return;
+    try {
+      callback();
+    } catch (e) {
+      log('[Helium] Error in $name callback: $e');
+    }
+  }
+
   void _handlePaywallEvent(HeliumPaywallEvent heliumPaywallEvent) {
     final trigger = heliumPaywallEvent.triggerName;
     switch (heliumPaywallEvent.type) {
@@ -928,11 +937,8 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
         if (trigger != null &&
             unavailableReason != "alreadyPresented" &&
             unavailableReason != "secondTryNoMatch") {
-          try {
-            _currentOnPaywallUnavailable?.call();
-          } catch (e) {
-            log('[Helium] Error in onPaywallUnavailable callback: $e');
-          }
+          _safeInvokeCallback(
+              _currentOnPaywallUnavailable, 'onPaywallUnavailable');
           // Dispatch on next frame to let event handling finish processing
           WidgetsBinding.instance.addPostFrameCallback((_) {
             _showFallbackSheet(trigger);

--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -20,6 +20,12 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
   bool _isInitialized = false;
   PaywallEventHandlers? _currentEventHandlers;
 
+  /// Callbacks for the current [presentUpsell] presentation. [_currentOnEntitled]
+  /// is invoked from the native `onEntitled` closure (via the [onPaywallEntitledMethodName]
+  /// method call); [_currentOnPaywallUnavailable] is derived from `paywallOpenFailed`.
+  void Function()? _currentOnEntitled;
+  void Function()? _currentOnPaywallUnavailable;
+
   @override
   bool get isInitialized => _isInitialized;
 
@@ -214,6 +220,13 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
         final Map<String, dynamic> eventDict =
             (args is Map) ? Map<String, dynamic>.from(args) : {};
         _handlePaywallEventHandlers(HeliumPaywallEvent.fromMap(eventDict));
+      } else if (handler.method == onPaywallEntitledMethodName) {
+        try {
+          _currentOnEntitled?.call();
+        } catch (e) {
+          log('[Helium] Error in onEntitled callback: $e');
+        }
+        _currentOnEntitled = null;
       } else if (handler.method == onHeliumLogEventMethodName) {
         final dynamic args = handler.arguments;
         final Map<String, dynamic> eventMap =
@@ -323,11 +336,15 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
     PaywallEventHandlers? eventHandlers,
     Map<String, dynamic>? customPaywallTraits,
     bool? dontShowIfAlreadyEntitled,
+    void Function()? onEntitled,
+    void Function()? onPaywallUnavailable,
   }) async {
     _fallbackContext = context;
 
-    // Store current event handlers
+    // Store current event handlers and presentation callbacks
     _currentEventHandlers = eventHandlers;
+    _currentOnEntitled = onEntitled;
+    _currentOnPaywallUnavailable = onPaywallUnavailable;
 
     try {
       final result = await methodChannel.invokeMethod<String?>(
@@ -342,6 +359,8 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
     } on PlatformException catch (e) {
       log('[Helium] Unexpected present upsell error: ${e.message}');
       _currentEventHandlers = null;
+      _currentOnEntitled = null;
+      _currentOnPaywallUnavailable = null;
       await methodChannel.invokeMethod<String?>(
         fallbackOpenEventMethodName,
         {
@@ -351,6 +370,11 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
         },
       );
       _showFallbackSheet(trigger);
+      try {
+        onPaywallUnavailable?.call();
+      } catch (err) {
+        log('[Helium] Error in onPaywallUnavailable callback: $err');
+      }
       return "Failed to present upsell: '${e.message}'.";
     }
   }
@@ -823,11 +847,17 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
         if (heliumPaywallEvent.isSecondTry != true) {
           _currentEventHandlers = null;
           _fallbackContext = null;
+          // onEntitled is intentionally NOT cleared here: the native onEntitled
+          // closure fires when the paywall closes after a purchase, i.e. right
+          // after this event. It is cleared once it fires (or on the next
+          // presentUpsell).
+          _currentOnPaywallUnavailable = null;
         }
         break;
       case 'paywallSkipped':
         _currentEventHandlers = null;
         _fallbackContext = null;
+        _currentOnPaywallUnavailable = null;
         break;
       case 'paywallOpenFailed':
         _currentEventHandlers = null;
@@ -835,11 +865,17 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
         if (trigger != null &&
             unavailableReason != "alreadyPresented" &&
             unavailableReason != "secondTryNoMatch") {
+          try {
+            _currentOnPaywallUnavailable?.call();
+          } catch (e) {
+            log('[Helium] Error in onPaywallUnavailable callback: $e');
+          }
           // Dispatch on next frame to let event handling finish processing
           WidgetsBinding.instance.addPostFrameCallback((_) {
             _showFallbackSheet(trigger);
           });
         }
+        _currentOnPaywallUnavailable = null;
         break;
     }
   }

--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -944,6 +944,7 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
         _currentOnPaywallUnavailable = null;
         if (unavailableReason != "alreadyPresented" &&
             unavailableReason != "secondTryNoMatch") {
+          _currentOnEntitled = null;
           _safeInvokeCallback(onPaywallUnavailable, 'onPaywallUnavailable');
           if (trigger != null) {
             // Dispatch on next frame to let event handling finish processing

--- a/packages/helium_flutter/lib/core/helium_flutter_platform.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_platform.dart
@@ -74,6 +74,8 @@ abstract class HeliumFlutterPlatform extends PlatformInterface {
     PaywallEventHandlers? eventHandlers,
     Map<String, dynamic>? customPaywallTraits,
     bool? dontShowIfAlreadyEntitled,
+    void Function()? onEntitled,
+    void Function()? onPaywallUnavailable,
   });
 
   Future<bool> hideUpsell();

--- a/packages/helium_flutter/lib/helium_flutter.dart
+++ b/packages/helium_flutter/lib/helium_flutter.dart
@@ -118,12 +118,23 @@ class HeliumFlutter {
   }
 
   ///Presents view based on [trigger]
+  ///
+  /// [onEntitled] is called when the user becomes entitled to a product on the
+  /// paywall — on purchase success or restore. If [dontShowIfAlreadyEntitled]
+  /// is true, it is also called instead of showing the paywall when the user
+  /// already owns a product on it.
+  ///
+  /// [onPaywallUnavailable] is called if neither the configured paywall nor the
+  /// fallback paywall could be shown for any reason. This is uncommon, but best
+  /// practice to handle. See https://docs.tryhelium.com/guides/fallback-bundle
   Future<String?> presentUpsell({
     required BuildContext context,
     required String trigger,
     PaywallEventHandlers? eventHandlers,
     Map<String, dynamic>? customPaywallTraits,
     bool? dontShowIfAlreadyEntitled,
+    void Function()? onEntitled,
+    void Function()? onPaywallUnavailable,
   }) =>
       HeliumFlutterPlatform.instance.presentUpsell(
         context: context,
@@ -131,6 +142,8 @@ class HeliumFlutter {
         eventHandlers: eventHandlers,
         customPaywallTraits: customPaywallTraits,
         dontShowIfAlreadyEntitled: dontShowIfAlreadyEntitled,
+        onEntitled: onEntitled,
+        onPaywallUnavailable: onPaywallUnavailable,
       );
 
   Future<PaywallInfo?> getPaywallInfo(String trigger) =>

--- a/packages/helium_flutter/lib/helium_flutter.dart
+++ b/packages/helium_flutter/lib/helium_flutter.dart
@@ -53,6 +53,11 @@ class HeliumFlutter {
   }
 
   ///Initialize helium sdk at the start-up of your flutter application.
+  ///
+  /// [fallbackPaywall] is a Flutter widget shown as a last-resort view when a
+  /// Helium paywall cannot be displayed. Prefer handling the
+  /// `onPaywallUnavailable` callback on [presentUpsell] instead — the
+  /// [fallbackPaywall] widget is planned for removal in the next major release.
   Future<String?> initialize({
     required String apiKey,
     HeliumCallbacks? callbacks,
@@ -125,9 +130,14 @@ class HeliumFlutter {
   /// is true, it is also called instead of showing the paywall when the user
   /// already owns a product on it.
   ///
-  /// [onPaywallUnavailable] is called if neither the configured paywall nor the
-  /// fallback paywall could be shown for any reason. This is uncommon, but best
-  /// practice to handle. See https://docs.tryhelium.com/guides/fallback-bundle
+  /// [onPaywallUnavailable] is called when the Helium paywall for [trigger]
+  /// cannot be shown — neither the configured paywall nor a Helium fallback
+  /// paywall displayed. Uncommon, but best practice to handle.
+  ///
+  /// This is independent of the Flutter [fallbackPaywall] view: if you supplied
+  /// one to [initialize] it is still shown as a last resort, but this callback
+  /// is still called so you can react to the Helium paywall being unavailable.
+  /// See https://docs.tryhelium.com/guides/fallback-bundle
   Future<String?> presentUpsell({
     required BuildContext context,
     required String trigger,

--- a/packages/helium_flutter/pubspec.yaml
+++ b/packages/helium_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: helium_flutter
 description: "Flutter Paywall SDK for Helium. Remotely build and auto-optimize paywalls (tryhelium.com)"
 
 # Remember to update CHANGELOG.md when releasing a new version!!! (see CONTRIBUTING.md)
-version: 3.3.5
+version: 3.3.6
 
 homepage: https://tryhelium.com
 license: MIT

--- a/packages/helium_flutter/test/helium_flutter_method_channel_test.dart
+++ b/packages/helium_flutter/test/helium_flutter_method_channel_test.dart
@@ -214,4 +214,25 @@ void main() {
     await tester.pump();
     expect(unavailableCalls, 0);
   });
+
+  testWidgets('onPaywallUnavailable fires even when triggerName is absent',
+      (WidgetTester tester) async {
+    await pumpContext(tester);
+    await platform.initialize(apiKey: initializeValue.apiKey);
+
+    var unavailableCalls = 0;
+    await platform.presentUpsell(
+      context: context,
+      trigger: 'onboarding',
+      onPaywallUnavailable: () => unavailableCalls++,
+    );
+
+    // Missing triggerName gates only the Flutter fallback view, not the callback.
+    await sendFromNative(const MethodCall(onPaywallEventMethodName, {
+      'type': 'paywallOpenFailed',
+      'paywallUnavailableReason': 'someError',
+    }));
+    await tester.pump();
+    expect(unavailableCalls, 1);
+  });
 }

--- a/packages/helium_flutter/test/helium_flutter_method_channel_test.dart
+++ b/packages/helium_flutter/test/helium_flutter_method_channel_test.dart
@@ -111,4 +111,107 @@ void main() {
       'Upsell presented!',
     );
   });
+
+  // Simulates a native -> Dart method call to the handler registered via
+  // setMethodCallHandler (i.e. how the native side reports events back).
+  Future<void> sendFromNative(MethodCall call) {
+    return TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+      heliumFlutter,
+      const StandardMethodCodec().encodeMethodCall(call),
+      (ByteData? _) {},
+    );
+  }
+
+  Future<void> pumpContext(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext ctx) {
+            context = ctx;
+            return const Scaffold(body: Text('Test'));
+          },
+        ),
+      ),
+    );
+  }
+
+  testWidgets('onEntitled fires on onPaywallEntitled and then clears',
+      (WidgetTester tester) async {
+    await pumpContext(tester);
+    await platform.initialize(apiKey: initializeValue.apiKey);
+
+    var entitledCalls = 0;
+    await platform.presentUpsell(
+      context: context,
+      trigger: 'onboarding',
+      onEntitled: () => entitledCalls++,
+    );
+
+    await sendFromNative(const MethodCall(onPaywallEntitledMethodName));
+    expect(entitledCalls, 1);
+
+    // Fires once, then clears — a second native call is a no-op.
+    await sendFromNative(const MethodCall(onPaywallEntitledMethodName));
+    expect(entitledCalls, 1);
+  });
+
+  testWidgets('a throwing onEntitled callback is contained',
+      (WidgetTester tester) async {
+    await pumpContext(tester);
+    await platform.initialize(apiKey: initializeValue.apiKey);
+
+    await platform.presentUpsell(
+      context: context,
+      trigger: 'onboarding',
+      onEntitled: () => throw Exception('boom'),
+    );
+
+    // Reaching the assertion means the exception did not propagate out of the
+    // method-channel handler.
+    await sendFromNative(const MethodCall(onPaywallEntitledMethodName));
+    expect(true, isTrue);
+  });
+
+  testWidgets('onPaywallUnavailable fires on paywallOpenFailed',
+      (WidgetTester tester) async {
+    await pumpContext(tester);
+    await platform.initialize(apiKey: initializeValue.apiKey);
+
+    var unavailableCalls = 0;
+    await platform.presentUpsell(
+      context: context,
+      trigger: 'onboarding',
+      onPaywallUnavailable: () => unavailableCalls++,
+    );
+
+    await sendFromNative(const MethodCall(onPaywallEventMethodName, {
+      'type': 'paywallOpenFailed',
+      'triggerName': 'onboarding',
+      'paywallUnavailableReason': 'someError',
+    }));
+    await tester.pump(); // flush the post-frame fallback-sheet dispatch (no-op)
+    expect(unavailableCalls, 1);
+  });
+
+  testWidgets('onPaywallUnavailable is skipped for alreadyPresented',
+      (WidgetTester tester) async {
+    await pumpContext(tester);
+    await platform.initialize(apiKey: initializeValue.apiKey);
+
+    var unavailableCalls = 0;
+    await platform.presentUpsell(
+      context: context,
+      trigger: 'onboarding',
+      onPaywallUnavailable: () => unavailableCalls++,
+    );
+
+    await sendFromNative(const MethodCall(onPaywallEventMethodName, {
+      'type': 'paywallOpenFailed',
+      'triggerName': 'onboarding',
+      'paywallUnavailableReason': 'alreadyPresented',
+    }));
+    await tester.pump();
+    expect(unavailableCalls, 0);
+  });
 }

--- a/packages/helium_flutter/test/helium_flutter_test.dart
+++ b/packages/helium_flutter/test/helium_flutter_test.dart
@@ -90,6 +90,8 @@ class MockHeliumFlutterPlatform
     PaywallEventHandlers? eventHandlers,
     Map<String, dynamic>? customPaywallTraits,
     bool? dontShowIfAlreadyEntitled,
+    void Function()? onEntitled,
+    void Function()? onPaywallUnavailable,
   }) {
     return Future.value('Upsell presented!');
   }
@@ -279,7 +281,11 @@ void main() {
 
     expect(
       await heliumFlutterPlugin.presentUpsell(
-          context: context, trigger: 'onboarding'),
+        context: context,
+        trigger: 'onboarding',
+        onEntitled: () {},
+        onPaywallUnavailable: () {},
+      ),
       'Upsell presented!',
     );
   });

--- a/packages/helium_revenuecat/CHANGELOG.md
+++ b/packages/helium_revenuecat/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.6
+- Bumped to stay in sync with helium_flutter 3.3.6 (adds `onEntitled` / `onPaywallUnavailable` callbacks to `presentUpsell`).
+
 ## 3.3.5
 - Updated helium-swift dependency to 4.5.5 and Helium Android dependency to 4.4.7
 

--- a/packages/helium_revenuecat/pubspec.yaml
+++ b/packages/helium_revenuecat/pubspec.yaml
@@ -1,6 +1,6 @@
 name: helium_revenuecat
 description: "Helium RevenueCat SDK. Remotely build and auto-optimize paywalls (tryhelium.com)"
-version: 3.3.5
+version: 3.3.6
 homepage: https://tryhelium.com
 
 environment:

--- a/packages/helium_stripe/test/helium_stripe_test.dart
+++ b/packages/helium_stripe/test/helium_stripe_test.dart
@@ -102,6 +102,8 @@ class MockHeliumFlutterPlatform
     PaywallEventHandlers? eventHandlers,
     Map<String, dynamic>? customPaywallTraits,
     bool? dontShowIfAlreadyEntitled,
+    void Function()? onEntitled,
+    void Function()? onPaywallUnavailable,
   }) async =>
       'Upsell presented!';
   @override


### PR DESCRIPTION
## Summary

Adds two optional callbacks to `presentUpsell`, matching the Expo SDK:

- **`onEntitled`** — fires when the user becomes entitled to a product on the paywall: on purchase success, restore, or (with `dontShowIfAlreadyEntitled: true`) the already-entitled skip.
- **`onPaywallUnavailable`** — fires when neither the configured paywall nor the fallback could be shown for any reason.

Scope is `presentUpsell` only (not `getUpsellWidget`), by design.

## Implementation

**`onEntitled` — native closure (authoritative):**
- The iOS/Android bridges pass an `onEntitled` closure to the native `presentPaywall`, which invokes a new `onPaywallEntitled` method-channel call back to Dart (dispatched to main thread).
- The method channel routes `onPaywallEntitled` → the stored `_currentOnEntitled`, then clears it.
- Using the native closure (rather than deriving from events) keeps it correct across all cases — purchase, restore, `purchaseAlreadyEntitled`, already-entitled skip — and resilient as the native SDK evolves. Deliberately **not** cleared on `paywallClose`, since the native closure fires *at* close after a purchase.

**`onPaywallUnavailable` — event-derived (matches Expo):**
- Fired from the existing `paywallOpenFailed` branch of `_handlePaywallEvent`, reusing the same `alreadyPresented` / `secondTryNoMatch` filtering; also fired on the bridging-error path. Cleared on `paywallClose` / `paywallSkipped` / `paywallOpenFailed`.

Both callbacks are wrapped in try/catch so a throwing user callback can't crash the SDK. `onEntitled`/`onPaywallNotShown` exist in the native SDK versions on `main` (iOS 4.5.5 / Android 4.4.7), so no dependency bump was needed.

**Also:** public API + platform interface signatures, both test mocks (`helium_flutter`, `helium_stripe`), the example app's Present-upsell button, and version bump to **3.3.6** (helium_flutter + helium_revenuecat) with CHANGELOG entries to cut a release on merge.

## Testing

- `helium_flutter`: `flutter analyze` clean, 37 tests pass
- `helium_stripe`: `flutter analyze` clean, 9 tests pass
- `helium_revenuecat`: `flutter analyze` clean, tests pass
- Version-consistency check (pubspec ↔ `contants.dart`) matches at 3.3.6

Note: `flutter analyze`/tests exercise the Dart layer only. The Swift/Kotlin `onEntitled` wiring uses each SDK's documented `presentPaywall(onEntitled:)` closure; a full native build of the example app on each platform was not run.

⚠️ Heads up: automated pub.dev publishing is currently broken (tracked in SDK-44). Merging this will create the 3.3.6 tag/release, but the pub.dev publish step won't auto-trigger until SDK-44 is fixed — may need a manual publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes paywall presentation and entitlement/unavailable signaling across Dart and native bridges; behavior is well-tested on the Dart side but full native example builds were not run.
> 
> **Overview**
> **`presentUpsell`** gains optional **`onEntitled`** and **`onPaywallUnavailable`** callbacks (aligned with the Expo SDK), scoped to modal presentation only—not **`getUpsellWidget`**.
> 
> **`onEntitled`** is driven by the native **`presentPaywall(onEntitled:)`** closure on iOS and Android, which invokes a new **`onPaywallEntitled`** method-channel call into Dart. The handler runs the stored callback once (not cleared on **`paywallClose`** so post-purchase entitlement still fires).
> 
> **`onPaywallUnavailable`** is derived from **`paywallOpenFailed`** (with existing **`alreadyPresented`** / **`secondTryNoMatch`** filters), bridging errors on **`presentUpsell`**, and still fires when **`triggerName`** is missing—only the Flutter fallback sheet is gated by trigger. User callbacks are wrapped in **`_safeInvokeCallback`** so throws cannot crash the SDK.
> 
> Public API, platform interface, example app, CHANGELOG, and version **3.3.6** (**`helium_flutter`** + **`helium_revenuecat`**) are updated; widget tests cover one-shot entitlement, contained errors, and unavailable paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc323b0e626e67c2673ecea6b646eeda6f03f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `onEntitled` callback support to `presentUpsell`, invoked when entitlement is confirmed.
  * Added `onPaywallUnavailable` callback support to `presentUpsell` when the paywall (and fallback) can’t be shown.
  * Updated native-to-Dart event forwarding for upsell entitlement/unavailability.

* **Bug Fixes**
  * Improved handling of paywall open failures and fallback behavior, including correct callback triggering/skipping.

* **Tests**
  * Added/updated widget tests to verify the new callback behavior.

* **Documentation**
  * Updated public API docs and release versions to **3.3.6**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->