### PR TITLE
Add clearCustomUserId() and release 3.3.7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,4 +21,6 @@ We also maintain an Expo/React Native SDK (`helium-expo`) that wraps the same na
 
 ## Testing
 
-When adding or changing a method on `HeliumFlutterPlatform`, also update the `MockHeliumFlutterPlatform` in `packages/helium_flutter/test/helium_flutter_test.dart` — otherwise `flutter analyze` fails with `non_abstract_class_inherits_abstract_member` or `invalid_override`.
+When adding or changing a method on `HeliumFlutterPlatform`, update every mock that implements it — search the packages for `implements HeliumFlutterPlatform` (there's currently one in each of `helium_flutter` and `helium_stripe`'s test folders) — otherwise `flutter analyze` fails with `non_abstract_class_inherits_abstract_member` or `invalid_override`.
+
+Such a change can break a mock in any package, so run `flutter analyze` and `flutter test` across all packages, not just `helium_flutter`.

--- a/packages/helium_flutter/CHANGELOG.md
+++ b/packages/helium_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.7
+- Added `clearCustomUserId()` to clear the custom user ID set via `overrideUserId`, reverting to Helium's anonymous user ID (e.g. on sign-out). Note that `resetHelium` does not clear the custom user ID.
+
 ## 3.3.6
 - Added `onEntitled` and `onPaywallUnavailable` callbacks to `presentUpsell`. `onEntitled` fires when the user becomes entitled (purchase, restore, or already-entitled skip when `dontShowIfAlreadyEntitled` is set); `onPaywallUnavailable` fires when neither the paywall nor fallback could be shown.
 

--- a/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
+++ b/packages/helium_flutter/android/src/main/kotlin/com/helium/helium_flutter/HeliumFlutterPlugin.kt
@@ -256,6 +256,10 @@ class HeliumFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
         result.success("User id is updated!")
       }
+      "clearCustomUserId" -> {
+        Helium.identity.userId = null
+        result.success("Custom user id cleared!")
+      }
       "fallbackOpenEvent" -> {
         result.notImplemented()
       }

--- a/packages/helium_flutter/ios/helium_flutter/Sources/helium_flutter/HeliumFlutterPlugin.swift
+++ b/packages/helium_flutter/ios/helium_flutter/Sources/helium_flutter/HeliumFlutterPlugin.swift
@@ -98,6 +98,9 @@ public class HeliumFlutterPlugin: NSObject, FlutterPlugin {
             } else {
                 result(FlutterError(code: "BAD_ARGS", message: "Arguments not passed correctly", details: nil))
             }
+        case "clearCustomUserId":
+            Helium.identify.userId = nil
+            result("Custom user id cleared!")
         case "fallbackOpenEvent":
             if let args = call.arguments as? [String: Any] {
                 let trigger = args["trigger"] as? String

--- a/packages/helium_flutter/lib/core/const/contants.dart
+++ b/packages/helium_flutter/lib/core/const/contants.dart
@@ -1,5 +1,5 @@
 // SDK version - keep in sync with pubspec.yaml
-const String heliumFlutterSdkVersion = '3.3.6';
+const String heliumFlutterSdkVersion = '3.3.7';
 
 //Native view type
 const String upsellViewForTrigger = 'upsellViewForTrigger';
@@ -18,6 +18,7 @@ const String onPaywallEntitledMethodName = 'onPaywallEntitled';
 const String getHeliumUserIdMethodName = 'getHeliumUserId';
 const String hideUpsellMethodName = 'hideUpsell';
 const String overrideUserIdMethodName = 'overrideUserId';
+const String clearCustomUserIdMethodName = 'clearCustomUserId';
 const String paywallsLoadedMethodName = 'paywallsLoaded';
 const String presentUpsellMethodName = 'presentUpsell';
 const String fallbackOpenEventMethodName = 'fallbackOpenEvent';

--- a/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_method_channel.dart
@@ -287,6 +287,15 @@ class HeliumFlutterMethodChannel extends HeliumFlutterPlatform {
   }
 
   @override
+  Future<void> clearCustomUserId() async {
+    try {
+      await methodChannel.invokeMethod<void>(clearCustomUserIdMethodName);
+    } catch (e) {
+      log('[Helium] Failed to clear custom user ID: $e');
+    }
+  }
+
+  @override
   Future<bool> paywallsLoaded() async {
     final result = await methodChannel.invokeMethod<bool?>(
       paywallsLoadedMethodName,

--- a/packages/helium_flutter/lib/core/helium_flutter_platform.dart
+++ b/packages/helium_flutter/lib/core/helium_flutter_platform.dart
@@ -95,6 +95,8 @@ abstract class HeliumFlutterPlatform extends PlatformInterface {
     Map<String, dynamic>? traits,
   });
 
+  Future<void> clearCustomUserId();
+
   Future<PaywallInfo?> getPaywallInfo(String trigger);
 
   Future<bool> handleDeepLink(String uri);

--- a/packages/helium_flutter/lib/helium_flutter.dart
+++ b/packages/helium_flutter/lib/helium_flutter.dart
@@ -109,6 +109,13 @@ class HeliumFlutter {
         traits: traits,
       );
 
+  /// Clears the custom user ID previously set via [overrideUserId], reverting
+  /// to Helium's anonymous user ID. Use when a user signs out.
+  ///
+  /// Note: [resetHelium] does not clear the custom user ID.
+  Future<void> clearCustomUserId() =>
+      HeliumFlutterPlatform.instance.clearCustomUserId();
+
   ///Returns true if Helium paywalls are loaded.
   Future<bool> paywallsLoaded() =>
       HeliumFlutterPlatform.instance.paywallsLoaded();

--- a/packages/helium_flutter/pubspec.yaml
+++ b/packages/helium_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: helium_flutter
 description: "Flutter Paywall SDK for Helium. Remotely build and auto-optimize paywalls (tryhelium.com)"
 
 # Remember to update CHANGELOG.md when releasing a new version!!! (see CONTRIBUTING.md)
-version: 3.3.6
+version: 3.3.7
 
 homepage: https://tryhelium.com
 license: MIT

--- a/packages/helium_flutter/test/helium_flutter_test.dart
+++ b/packages/helium_flutter/test/helium_flutter_test.dart
@@ -79,6 +79,11 @@ class MockHeliumFlutterPlatform
   }
 
   @override
+  Future<void> clearCustomUserId() {
+    return Future.value();
+  }
+
+  @override
   Future<bool> paywallsLoaded() {
     return Future.value(true);
   }
@@ -279,6 +284,10 @@ void main() {
       ),
       'new_user_id',
     );
+  });
+  test(clearCustomUserIdMethodName, () async {
+    // Completes without throwing.
+    await heliumFlutterPlugin.clearCustomUserId();
   });
   test(paywallsLoadedMethodName, () async {
     expect(await heliumFlutterPlugin.paywallsLoaded(), true);

--- a/packages/helium_revenuecat/CHANGELOG.md
+++ b/packages/helium_revenuecat/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.7
+- Bumped to stay in sync with helium_flutter 3.3.7 (adds `clearCustomUserId()`).
+
 ## 3.3.6
 - Bumped to stay in sync with helium_flutter 3.3.6 (adds `onEntitled` / `onPaywallUnavailable` callbacks to `presentUpsell`).
 

--- a/packages/helium_revenuecat/pubspec.yaml
+++ b/packages/helium_revenuecat/pubspec.yaml
@@ -1,6 +1,6 @@
 name: helium_revenuecat
 description: "Helium RevenueCat SDK. Remotely build and auto-optimize paywalls (tryhelium.com)"
-version: 3.3.6
+version: 3.3.7
 homepage: https://tryhelium.com
 
 environment:

--- a/packages/helium_stripe/test/helium_stripe_test.dart
+++ b/packages/helium_stripe/test/helium_stripe_test.dart
@@ -88,6 +88,11 @@ class MockHeliumFlutterPlatform
   }
 
   @override
+  Future<void> clearCustomUserId() async {
+    calls.add('clearCustomUserId');
+  }
+
+  @override
   Future<String?> getHeliumUserId() async => 'user_id';
   @override
   Future<bool> hideUpsell() async => true;


### PR DESCRIPTION
## What

Adds `clearCustomUserId()` to the public `HeliumFlutter` API — clears the custom user ID set via `overrideUserId`, reverting to Helium's anonymous user ID (e.g. on sign-out). Mirrors the Expo SDK's `clearCustomUserId`.

Motivation: integrators need to change the user ID after `initialize`, and to *unset* it. `overrideUserId` already covers setting/changing it, but there was no way to clear it — `overrideUserId` requires a non-null id, and `resetHelium` does **not** clear the user ID (its native `clearUserId` defaults to `false` and is not passed).

## Changes

- `clearCustomUserId()` wired through the Dart public API, platform interface, method channel, and both native plugins:
  - iOS: `Helium.identify.userId = nil`
  - Android: `Helium.identity.userId = null`
- Method-channel call is wrapped so it never throws to the caller.
- Mock override + test added (per repo testing convention).
- Version bump to **3.3.7** for both `helium_flutter` and `helium_revenuecat`, with changelog entries. Pushing the `helium_flutter` pubspec bump to `main` triggers the tag/release/publish workflow.

## Not included (intentionally, to keep this focused)

- `getCustomUserId` and `presentUpsell(androidDisableSystemBackNavigation:)` — other Expo-parity gaps, deemed non-critical for this release.

## Testing

- `flutter analyze` — no issues.
- `flutter test` — all 43 tests pass, including the new `clearCustomUserId` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive identity API with defensive error handling; behavior depends on native SDK clearing `userId` correctly but scope is narrow and aligned with existing `overrideUserId`.
> 
> **Overview**
> Adds **`clearCustomUserId()`** on the public `HeliumFlutter` API so apps can drop a custom ID set with `overrideUserId` and return to Helium’s anonymous user (e.g. on sign-out). Docs call out that **`resetHelium` does not** clear the custom user ID.
> 
> The call is wired through the platform interface and method channel to **iOS** (`Helium.identify.userId = nil`) and **Android** (`Helium.identity.userId = null`). The Dart method-channel path is wrapped so failures are logged and **never thrown** to the host app.
> 
> **3.3.7** bumps `helium_flutter` and `helium_revenuecat` with changelog entries; test mocks in `helium_flutter` and `helium_stripe` plus a small test were updated, and **CLAUDE.md** now says to update every `HeliumFlutterPlatform` mock when the interface changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb0609945d3938b439d7a21dcf0b788959563c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `clearCustomUserId()` to remove a custom user ID and restore Helium’s anonymous user ID, such as after sign-out.
  * Available across Flutter, Android, and iOS integrations.

* **Documentation**
  * Clarified that resetting Helium does not remove a custom user ID.

* **Chores**
  * Updated Helium Flutter and RevenueCat package versions to 3.3.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->