### PR TITLE
Example: use clearCustomUserId() and add a Clear user ID button

### DIFF
--- a/example/lib/presentation/home_page.dart
+++ b/example/lib/presentation/home_page.dart
@@ -42,7 +42,7 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _clearUserId() async {
-    await _heliumFlutterPlugin.overrideUserId(newUserId: '');
+    await _heliumFlutterPlugin.clearCustomUserId();
     await _refreshHeliumUserId();
   }
 
@@ -133,6 +133,11 @@ class _HomePageState extends State<HomePage> {
                 buttonKey: const ValueKey('set_user_id'),
                 label: 'Set random user ID',
                 onPressed: _setRandomUserId,
+              ),
+              _ActionButton(
+                buttonKey: const ValueKey('clear_user_id'),
+                label: 'Clear user ID',
+                onPressed: _clearUserId,
               ),
               const SizedBox(height: 8),
               _IdLabel(


### PR DESCRIPTION
Follow-up to #107 (which added `clearCustomUserId()`).

## What
- The example app's `_clearUserId()` called `overrideUserId(newUserId: '')`, which sets the custom user ID to the **empty string** rather than clearing it — it doesn't revert to Helium's anonymous ID, and it was also dead code (no button referenced it). Switched it to the new `clearCustomUserId()`.
- Added a **"Clear user ID"** button (key `clear_user_id`) next to "Set random user ID", wired to `_clearUserId()`.

## Testing
- `flutter analyze` on the example — no new issues. (There's one pre-existing `unused_import` warning in `main.dart`, unrelated to this change and left as-is.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app-only UI and API usage change with no impact on the published SDK or production paths.
> 
> **Overview**
> The example app’s user-ID reset now calls **`clearCustomUserId()`** instead of **`overrideUserId(newUserId: '')`**, so clearing actually drops the custom ID rather than storing an empty string.
> 
> A **“Clear user ID”** button (`clear_user_id`) was added in the User status section and wired to that handler, making the flow testable in the demo UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f4d294d3f99147b03a7c368d4cfdddeaf25f9cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Clear user ID” action so it properly removes the saved user ID instead of replacing it with an empty value.
  * Added a clearly labeled “Clear user ID” button to the User status section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->