### PR TITLE
Fix automated pub.dev publishing by tagging with a GitHub App token

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -95,12 +95,21 @@ jobs:
     needs: [check-version, get-current-version, test]
     if: always() && (needs.check-version.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch')
     steps:
+      # Tag must be pushed with an app token (not the default GITHUB_TOKEN,
+      # which suppresses downstream workflow triggers) so publish.yml runs.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.HELIUM_RELEASE_APP_ID }}
+          private-key: ${{ secrets.HELIUM_RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Create tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ needs.check-version.outputs.new-version || needs.get-current-version.outputs.current-version }}"
           git tag "$VERSION"


### PR DESCRIPTION
## Problem
Automated pub.dev publishing has been broken since Feb 2026 (SDK-44). `create-release.yml` pushes the release tag using the default `GITHUB_TOKEN`, and GitHub intentionally does not trigger downstream workflows from events created with that token — so the tag never fires `publish.yml`'s `on: push: tags` trigger. Manually pushed tags still worked, which is why manual publishing has been the workaround.

Regression introduced in `1c45aa2`, which replaced the PAT-authenticated tag action (`FLUTTER_TAG_KEY`, since deleted) with a plain `git push` under `GITHUB_TOKEN`.

## Fix
The `release` job now mints a short-lived installation token from a new GitHub App (`helium-flutter-deployment-app`, installed on this repo) via `actions/create-github-app-token@v2`, and checks out with it so the tag push authenticates as the App. Tags pushed by the App do generate events, so `publish.yml` triggers again.

Secrets `HELIUM_RELEASE_APP_ID` and `HELIUM_RELEASE_APP_PRIVATE_KEY` are already configured in the repo.

`publish.yml` is intentionally untouched — its tag-push trigger + OIDC setup is the pattern pub.dev requires.

## Verification
- YAML validated locally; no live dry-run is possible (tagging an already-tagged version fails by design).
- Real proof is the next release: the version-bump commit should chain into a "Publish to pub.dev" run in the Actions tab with no manual tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release automation and secrets for tag push auth; misconfiguration could break tagging or leave publish still untriggered, but scope is limited to CI and `publish.yml` is unchanged.
> 
> **Overview**
> Restores the automated release → pub.dev chain by pushing version tags as a **GitHub App** instead of the default `GITHUB_TOKEN`.
> 
> The `release` job in `create-release.yml` now mints a short-lived token via `actions/create-github-app-token@v2`, checks out with that token, and drops `GITHUB_TOKEN` from the tag push step so `git push origin <version>` counts as an App event. That allows `publish.yml`’s `on: push: tags` trigger to run again (GitHub suppresses downstream workflows for tag pushes made with `GITHUB_TOKEN`). **Create GitHub Release** still uses `GITHUB_TOKEN` for `gh release create`; only tagging/auth for push changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ad27fe28e6f0cdf8d709809816be42bc9aa1b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to improve authentication and reliability during automated releases.
  * No changes to product functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->